### PR TITLE
nits on ERC20.sol

### DIFF
--- a/src/erc20/ERC20.sol
+++ b/src/erc20/ERC20.sol
@@ -73,6 +73,7 @@ contract ERC20 {
     /*///////////////////////////////////////////////////////////////
                               ERC20 LOGIC
     //////////////////////////////////////////////////////////////*/
+    
     function approve(address spender, uint256 value) external returns (bool) {
         allowance[msg.sender][spender] = value;
 
@@ -83,7 +84,7 @@ contract ERC20 {
 
     function transfer(address to, uint256 value) external returns (bool) {
         balanceOf[msg.sender] -= value;
-        balanceOf[to] += value;
+        unchecked { balanceOf[to] += value; }
 
         emit Transfer(msg.sender, to, value);
 
@@ -100,7 +101,7 @@ contract ERC20 {
         }
 
         balanceOf[from] -= value;
-        balanceOf[to] += value;
+        unchecked { balanceOf[to] += value; }
 
         emit Transfer(from, to, value);
 

--- a/src/erc20/ERC20.sol
+++ b/src/erc20/ERC20.sol
@@ -86,6 +86,9 @@ contract ERC20 {
 
     function transfer(address to, uint256 value) external returns (bool) {
         balanceOf[msg.sender] -= value;
+        // This is safe, as sum of all user balances will never exceed
+        // type(uint256).max since totalSupply would overflow in _mint and
+        // Solidity's default checked math would force the function to revert.
         unchecked { balanceOf[to] += value; }
 
         emit Transfer(msg.sender, to, value);
@@ -103,6 +106,9 @@ contract ERC20 {
         }
 
         balanceOf[from] -= value;
+        // This is safe, as sum of all user balances will never exceed
+        // type(uint256).max since totalSupply would overflow in _mint and
+        // Solidity's default checked math would force the function to revert.
         unchecked { balanceOf[to] += value; }
 
         emit Transfer(from, to, value);


### PR DESCRIPTION
lil space nit 😛// also we can save some gas by doing 'unchecked' for resulting balances from `transfer` ~ `transferFrom`? (since we checked sender balance with implicit safeMath)