### PR TITLE
♻️ Convert external erc20 methods to public

### DIFF
--- a/src/erc20/ERC20.sol
+++ b/src/erc20/ERC20.sol
@@ -67,7 +67,7 @@ contract ERC20 {
                               ERC20 LOGIC
     //////////////////////////////////////////////////////////////*/
 
-    function approve(address spender, uint256 value) external returns (bool) {
+    function approve(address spender, uint256 value) public returns (bool) {
         allowance[msg.sender][spender] = value;
 
         emit Approval(msg.sender, spender, value);
@@ -75,7 +75,7 @@ contract ERC20 {
         return true;
     }
 
-    function transfer(address to, uint256 value) external returns (bool) {
+    function transfer(address to, uint256 value) public returns (bool) {
         balanceOf[msg.sender] -= value;
 
         // This is safe because the sum of all user
@@ -93,7 +93,7 @@ contract ERC20 {
         address from,
         address to,
         uint256 value
-    ) external returns (bool) {
+    ) public returns (bool) {
         if (allowance[from][msg.sender] != type(uint256).max) {
             allowance[from][msg.sender] -= value;
         }
@@ -123,7 +123,7 @@ contract ERC20 {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external {
+    ) public {
         require(deadline >= block.timestamp, "PERMIT_DEADLINE_EXPIRED");
 
         bytes32 digest = keccak256(

--- a/src/erc20/ERC20.sol
+++ b/src/erc20/ERC20.sol
@@ -67,7 +67,7 @@ contract ERC20 {
                               ERC20 LOGIC
     //////////////////////////////////////////////////////////////*/
 
-    function approve(address spender, uint256 value) public returns (bool) {
+    function approve(address spender, uint256 value) public virtual returns (bool) {
         allowance[msg.sender][spender] = value;
 
         emit Approval(msg.sender, spender, value);
@@ -75,7 +75,7 @@ contract ERC20 {
         return true;
     }
 
-    function transfer(address to, uint256 value) public returns (bool) {
+    function transfer(address to, uint256 value) public virtual returns (bool) {
         balanceOf[msg.sender] -= value;
 
         // This is safe because the sum of all user
@@ -93,7 +93,7 @@ contract ERC20 {
         address from,
         address to,
         uint256 value
-    ) public returns (bool) {
+    ) public virtual returns (bool) {
         if (allowance[from][msg.sender] != type(uint256).max) {
             allowance[from][msg.sender] -= value;
         }
@@ -123,7 +123,7 @@ contract ERC20 {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) public {
+    ) public virtual {
         require(deadline >= block.timestamp, "PERMIT_DEADLINE_EXPIRED");
 
         bytes32 digest = keccak256(


### PR DESCRIPTION
Methods touched are: `approve`, `transfer`, `transferFrom`, and `permit`.

Motivations for this PR are that it:
* Conforms to the [ERC20 standard](https://eips.ethereum.org/EIPS/eip-20) 
* Aligns with [OpenZeppelin's ERC20 implementation](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/ERC20.sol)
* Allows inheriting contracts to call these methods with `super`, enabling more flexible usage (e.g. for aave-style tokens that add an extra call on every `transfer`)

A question is if there are extra gas costs to using `public` here, but my understanding is that the arguments ([1](https://gus-tavo-guim.medium.com/public-vs-external-functions-in-solidity-b46bcf0ba3ac), [2](https://ethereum.stackexchange.com/questions/19380/external-vs-public-best-practices)) for that only apply to reference-type arguments.