### PR TITLE
🎨 ERC20: Style Nits

### DIFF
--- a/src/tokens/ERC20.sol
+++ b/src/tokens/ERC20.sol
@@ -59,7 +59,7 @@ abstract contract ERC20 {
         decimals = _decimals;
 
         INITIAL_CHAIN_ID = block.chainid;
-        INITIAL_DOMAIN_SEPARATOR = _computeDomainSeparator();
+        INITIAL_DOMAIN_SEPARATOR = computeDomainSeparator();
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -77,8 +77,8 @@ abstract contract ERC20 {
     function transfer(address to, uint256 amount) public virtual returns (bool) {
         balanceOf[msg.sender] -= amount;
 
-        // This is safe because the sum of all user
-        // balances can't exceed type(uint256).max.
+        // Cannot overflow because the sum of all user
+        // balances can't exceed the max uint256 value.
         unchecked {
             balanceOf[to] += amount;
         }
@@ -99,8 +99,8 @@ abstract contract ERC20 {
 
         balanceOf[from] -= amount;
 
-        // This is safe because the sum of all user
-        // balances can't exceed type(uint256).max.
+        // Cannot overflow because the sum of all user
+        // balances can't exceed the max uint256 value.
         unchecked {
             balanceOf[to] += amount;
         }
@@ -125,7 +125,7 @@ abstract contract ERC20 {
     ) public virtual {
         require(deadline >= block.timestamp, "PERMIT_DEADLINE_EXPIRED");
 
-        // This is safe because the only math done is incrementing
+        // Unchecked because the only math done is incrementing
         // the owner's nonce which cannot realistically overflow.
         unchecked {
             bytes32 digest = keccak256(
@@ -146,10 +146,10 @@ abstract contract ERC20 {
     }
 
     function DOMAIN_SEPARATOR() public view virtual returns (bytes32) {
-        return block.chainid == INITIAL_CHAIN_ID ? INITIAL_DOMAIN_SEPARATOR : _computeDomainSeparator();
+        return block.chainid == INITIAL_CHAIN_ID ? INITIAL_DOMAIN_SEPARATOR : computeDomainSeparator();
     }
 
-    function _computeDomainSeparator() internal view virtual returns (bytes32) {
+    function computeDomainSeparator() internal view virtual returns (bytes32) {
         return
             keccak256(
                 abi.encode(
@@ -169,8 +169,8 @@ abstract contract ERC20 {
     function _mint(address to, uint256 amount) internal virtual {
         totalSupply += amount;
 
-        // This is safe because the sum of all user
-        // balances can't exceed type(uint256).max.
+        // Cannot overflow because the sum of all user
+        // balances can't exceed the max uint256 value.
         unchecked {
             balanceOf[to] += amount;
         }
@@ -181,8 +181,8 @@ abstract contract ERC20 {
     function _burn(address from, uint256 amount) internal virtual {
         balanceOf[from] -= amount;
 
-        // This is safe because a user won't ever
-        // have a balance larger than totalSupply.
+        // Cannot underflow because a user's balance
+        // will never be larger than the total supply.
         unchecked {
             totalSupply -= amount;
         }

--- a/src/tokens/ERC20.sol
+++ b/src/tokens/ERC20.sol
@@ -59,7 +59,7 @@ abstract contract ERC20 {
         decimals = _decimals;
 
         INITIAL_CHAIN_ID = block.chainid;
-        INITIAL_DOMAIN_SEPARATOR = computeDomainSeparator();
+        INITIAL_DOMAIN_SEPARATOR = _computeDomainSeparator();
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -78,7 +78,7 @@ abstract contract ERC20 {
         balanceOf[msg.sender] -= amount;
 
         // This is safe because the sum of all user
-        // balances can't exceed type(uint256).max!
+        // balances can't exceed type(uint256).max.
         unchecked {
             balanceOf[to] += amount;
         }
@@ -100,7 +100,7 @@ abstract contract ERC20 {
         balanceOf[from] -= amount;
 
         // This is safe because the sum of all user
-        // balances can't exceed type(uint256).max!
+        // balances can't exceed type(uint256).max.
         unchecked {
             balanceOf[to] += amount;
         }
@@ -146,10 +146,10 @@ abstract contract ERC20 {
     }
 
     function DOMAIN_SEPARATOR() public view virtual returns (bytes32) {
-        return block.chainid == INITIAL_CHAIN_ID ? INITIAL_DOMAIN_SEPARATOR : computeDomainSeparator();
+        return block.chainid == INITIAL_CHAIN_ID ? INITIAL_DOMAIN_SEPARATOR : _computeDomainSeparator();
     }
 
-    function computeDomainSeparator() internal view virtual returns (bytes32) {
+    function _computeDomainSeparator() internal view virtual returns (bytes32) {
         return
             keccak256(
                 abi.encode(
@@ -170,7 +170,7 @@ abstract contract ERC20 {
         totalSupply += amount;
 
         // This is safe because the sum of all user
-        // balances can't exceed type(uint256).max!
+        // balances can't exceed type(uint256).max.
         unchecked {
             balanceOf[to] += amount;
         }
@@ -182,7 +182,7 @@ abstract contract ERC20 {
         balanceOf[from] -= amount;
 
         // This is safe because a user won't ever
-        // have a balance larger than totalSupply!
+        // have a balance larger than totalSupply.
         unchecked {
             totalSupply -= amount;
         }


### PR DESCRIPTION
- underscore `computeDomainSeparator` to match format of other internal functions (`_mint` / `_burn`)
- use periods rather than exclamation points to conform format and be more stoic, like a warrior monk ;0