### PR TITLE
[ERC4626] Fix bug: balanceOfUnderlying returns baseUnit when totalSupply is 0

### DIFF
--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -114,6 +114,8 @@ abstract contract ERC4626 is ERC20 {
     function totalHoldings() public view virtual returns (uint256);
 
     function balanceOfUnderlying(address user) public view virtual returns (uint256) {
+        if (balanceOf[user] == 0) return 0;
+
         return calculateUnderlying(balanceOf[user]);
     }
 


### PR DESCRIPTION
As part of an upcoming PR to add a test suite for ERC4626 I came across this bug in the following scenario:

`balanceOfUnderlying` is returning the `baseUnit` instead of 0.

```solidity
    function testAtomicDepositWithdraw() public {
        underlying.mint(address(this), 1e18);
        underlying.approve(address(vault), 1e18);

        uint256 preDepositBal = underlying.balanceOf(address(this));

        vault.deposit(address(this), 1e18);

        assertEq(vault.totalHoldings(), 1e18);
        assertEq(vault.balanceOf(address(this)), 1e18);
        assertEq(vault.balanceOfUnderlying(address(this)), 1e18);
        assertEq(underlying.balanceOf(address(this)), preDepositBal - 1e18);

        vault.withdraw(address(this), 1e18);

        assertEq(vault.totalHoldings(), 0);
        assertEq(vault.balanceOf(address(this)), 0);
        assertEq(vault.balanceOfUnderlying(address(this)), 0); << ERROR: 1000000000000000000
        assertEq(underlying.balanceOf(address(this)), preDepositBal);
    }
   ```
   
In order to handle this case I suggest checking if the user balance is 0 and returning early if so.