### PR TITLE
Fixed ERC4646 link

### DIFF
--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -6,7 +6,7 @@ import {SafeTransferLib} from "../utils/SafeTransferLib.sol";
 import {FixedPointMathLib} from "../utils/FixedPointMathLib.sol";
 
 /// @notice Minimal ERC4646 tokenized vault implementation.
-/// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/mixinz/ERC4626.sol)
+/// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/mixins/ERC4626.sol)
 abstract contract ERC4626 is ERC20 {
     using SafeTransferLib for ERC20;
     using FixedPointMathLib for uint256;


### PR DESCRIPTION
given that the contract would be merged with he current folder structure the current version would point to `mixinz` folder but the contract is stored in `mixins`