### PR TITLE
Implement ERC4626 test suite

### DIFF
--- a/.dapprc
+++ b/.dapprc
@@ -10,5 +10,5 @@ if [ "$DEEP_FUZZ" = "true" ]
 then 
   export DAPP_TEST_FUZZ_RUNS=10000 # Fuzz for a long time if DEEP_FUZZ is set to true.
 else
-  export DAPP_TEST_FUZZ_RUNS=100 # Only fuzz briefly if DEEP_FUZZ is not set to true.
+  export DAPP_TEST_FUZZ_RUNS=1000 # Only fuzz briefly if DEEP_FUZZ is not set to true.
 fi

--- a/.dapprc
+++ b/.dapprc
@@ -10,5 +10,5 @@ if [ "$DEEP_FUZZ" = "true" ]
 then 
   export DAPP_TEST_FUZZ_RUNS=10000 # Fuzz for a long time if DEEP_FUZZ is set to true.
 else
-  export DAPP_TEST_FUZZ_RUNS=1000 # Only fuzz briefly if DEEP_FUZZ is not set to true.
+  export DAPP_TEST_FUZZ_RUNS=100 # Only fuzz briefly if DEEP_FUZZ is not set to true.
 fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,173 @@
 {
   "name": "@rari-capital/solmate",
   "version": "6.2.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@rari-capital/solmate",
+      "version": "6.2.0",
+      "license": "AGPL-3.0-only",
+      "devDependencies": {
+        "prettier": "^2.3.1",
+        "prettier-plugin-solidity": "^1.0.0-beta.13"
+      }
+    },
+    "node_modules/@solidity-parser/parser": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.13.2.tgz",
+      "integrity": "sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==",
+      "dev": true,
+      "dependencies": {
+        "antlr4ts": "^0.5.0-alpha.4"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/antlr4ts": {
+      "version": "0.5.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.4.tgz",
+      "integrity": "sha512-WPQDt1B74OfPv/IMS2ekXAKkTZIHl88uMetg6q3OTqgFxZ/dxDXI0EWLyZid/1Pe6hTftyg5N7gel5wNAGxXyQ==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/prettier-plugin-solidity": {
+      "version": "1.0.0-beta.16",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-solidity/-/prettier-plugin-solidity-1.0.0-beta.16.tgz",
+      "integrity": "sha512-xVBcnoWpe52dNnCCbqPHC9ZrTWXcNfldf852ZD0DBcHDqVMwjHTAPEdfBVy6FczbFpVa8bmxQil+G5XkEz5WHA==",
+      "dev": true,
+      "dependencies": {
+        "@solidity-parser/parser": "^0.13.2",
+        "emoji-regex": "^9.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "semver": "^7.3.5",
+        "solidity-comments-extractor": "^0.0.7",
+        "string-width": "^4.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "prettier": "^2.3.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/solidity-comments-extractor": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/solidity-comments-extractor/-/solidity-comments-extractor-0.0.7.tgz",
+      "integrity": "sha512-wciNMLg/Irp8OKGrh3S2tfvZiZ0NEyILfcRCXCD4mp7SgK/i9gzLfhY2hY7VMCQJ3kH9UB9BzNdibIVMchzyYw==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    }
+  },
   "dependencies": {
     "@solidity-parser/parser": {
       "version": "0.13.2",

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -60,9 +60,9 @@ abstract contract ERC4626 is ERC20 {
     }
 
     function mint(address to, uint256 shareAmount) public virtual returns (uint256 underlyingAmount) {
-        _mint(to, shareAmount);
+        _mint(to, underlyingAmount = calculateUnderlying(shareAmount));
 
-        emit Deposit(msg.sender, to, underlyingAmount = calculateUnderlying(shareAmount));
+        emit Deposit(msg.sender, to, underlyingAmount);
 
         underlying.safeTransferFrom(msg.sender, address(this), underlyingAmount);
 

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -139,6 +139,7 @@ abstract contract ERC4626 is ERC20 {
 
     function calculateUnderlying(uint256 shareAmount) public view virtual returns (uint256) {
         uint256 shareSupply = totalSupply;
+
         if (shareSupply == 0) return shareAmount;
 
         uint256 exchangeRate = totalUnderlying().fdiv(shareSupply, baseUnit);

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -59,48 +59,52 @@ abstract contract ERC4626 is ERC20 {
         afterDeposit(underlyingAmount);
     }
 
-    function withdraw(address to, uint256 underlyingAmount) public virtual returns (uint256 shares) {
-        _burn(msg.sender, shares = calculateShares(underlyingAmount));
+    function mint(address to, uint256 shareAmount) public virtual returns (uint256 underlyingAmount) {
+        _mint(to, shareAmount);
 
-        emit Withdraw(msg.sender, to, underlyingAmount);
+        emit Deposit(msg.sender, to, underlyingAmount = calculateUnderlying(shareAmount));
 
-        beforeWithdraw(underlyingAmount);
+        underlying.safeTransferFrom(msg.sender, address(this), underlyingAmount);
 
-        underlying.safeTransfer(to, underlyingAmount);
+        afterDeposit(underlyingAmount);
     }
 
-    function redeem(address to, uint256 shareAmount) public virtual returns (uint256 underlyingAmount) {
-        _burn(msg.sender, shareAmount);
-
-        emit Withdraw(msg.sender, to, underlyingAmount = calculateUnderlying(shareAmount));
-
-        beforeWithdraw(underlyingAmount);
-
-        underlying.safeTransfer(to, underlyingAmount);
-    }
-
-    function withdrawFrom(
+    function withdraw(
         address from,
         address to,
         uint256 underlyingAmount
-    ) public virtual returns (uint256 shareAmount) {
-        if (allowance[from][msg.sender] != type(uint256).max) {
-            allowance[from][msg.sender] -= shareAmount;
+    ) public virtual returns (uint256 shares) {
+        shares = calculateShares(underlyingAmount);
+
+        if (msg.sender != from && allowance[from][msg.sender] != type(uint256).max) {
+            allowance[from][msg.sender] -= shares;
         }
 
-        redeem(to, shareAmount = calculateShares(underlyingAmount));
+        _burn(from, shares);
+
+        emit Withdraw(from, to, underlyingAmount);
+
+        beforeWithdraw(underlyingAmount);
+
+        underlying.safeTransfer(to, underlyingAmount);
     }
 
-    function redeemFrom(
+    function redeem(
         address from,
         address to,
         uint256 shareAmount
     ) public virtual returns (uint256 underlyingAmount) {
-        if (allowance[from][msg.sender] != type(uint256).max) {
+        if (msg.sender != from && allowance[from][msg.sender] != type(uint256).max) {
             allowance[from][msg.sender] -= shareAmount;
         }
 
-        withdraw(to, underlyingAmount = calculateUnderlying(shareAmount));
+        _burn(from, shareAmount);
+
+        emit Withdraw(from, to, underlyingAmount = calculateUnderlying(shareAmount));
+
+        beforeWithdraw(underlyingAmount);
+
+        underlying.safeTransfer(to, underlyingAmount);
     }
 
     function beforeWithdraw(uint256 underlyingAmount) internal virtual {}
@@ -120,16 +124,20 @@ abstract contract ERC4626 is ERC20 {
     function calculateShares(uint256 underlyingAmount) public view virtual returns (uint256) {
         uint256 shareSupply = totalSupply;
 
-        if (shareSupply == 0) return baseUnit;
+        if (shareSupply == 0) return underlyingAmount;
 
-        return underlyingAmount.fdiv(totalHoldings().fdiv(shareSupply, baseUnit), baseUnit);
+        uint256 exchangeRate = totalHoldings().fdiv(shareSupply, baseUnit);
+
+        return underlyingAmount.fdiv(exchangeRate, baseUnit);
     }
 
     function calculateUnderlying(uint256 shareAmount) public view virtual returns (uint256) {
         uint256 shareSupply = totalSupply;
 
-        if (shareSupply == 0) return baseUnit;
+        if (shareSupply == 0) return shareAmount;
 
-        return shareAmount.fmulUp(totalHoldings().fdiv(shareSupply, baseUnit), baseUnit);
+        uint256 exchangeRate = totalHoldings().fdiv(shareSupply, baseUnit);
+
+        return shareAmount.fmulUp(exchangeRate, baseUnit);
     }
 }

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -144,6 +144,6 @@ abstract contract ERC4626 is ERC20 {
 
         uint256 exchangeRate = totalUnderlying().fdiv(shareSupply, baseUnit);
 
-        return shareAmount.fmul(exchangeRate, baseUnit);
+        return shareAmount.fmulUp(exchangeRate, baseUnit);
     }
 }

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -60,9 +60,9 @@ abstract contract ERC4626 is ERC20 {
     }
 
     function mint(address to, uint256 shareAmount) public virtual returns (uint256 underlyingAmount) {
-        _mint(to, underlyingAmount = calculateUnderlying(shareAmount));
+        _mint(to, shareAmount);
 
-        emit Deposit(msg.sender, to, underlyingAmount);
+        emit Deposit(msg.sender, to, underlyingAmount = calculateUnderlying(shareAmount));
 
         underlying.safeTransferFrom(msg.sender, address(this), underlyingAmount);
 

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -114,6 +114,8 @@ abstract contract ERC4626 is ERC20 {
     function totalHoldings() public view virtual returns (uint256);
 
     function balanceOfUnderlying(address user) public view virtual returns (uint256) {
+        if (balanceOf[user] == 0) return 0;
+
         return calculateUnderlying(balanceOf[user]);
     }
 

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -114,8 +114,6 @@ abstract contract ERC4626 is ERC20 {
     function totalHoldings() public view virtual returns (uint256);
 
     function balanceOfUnderlying(address user) public view virtual returns (uint256) {
-        if (balanceOf[user] == 0) return 0;
-
         return calculateUnderlying(balanceOf[user]);
     }
 

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.10;
 
-import {DSTestPlus} from "../test/utils/DSTestPlus.sol";
 import {ERC20} from "../tokens/ERC20.sol";
 import {SafeTransferLib} from "../utils/SafeTransferLib.sol";
 import {FixedPointMathLib} from "../utils/FixedPointMathLib.sol";
 
 /// @notice Minimal ERC4646 tokenized vault implementation.
 /// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/mixins/ERC4626.sol)
-abstract contract ERC4626 is ERC20, DSTestPlus {
+abstract contract ERC4626 is ERC20 {
     using SafeTransferLib for ERC20;
     using FixedPointMathLib for uint256;
 
@@ -103,8 +102,6 @@ abstract contract ERC4626 is ERC20, DSTestPlus {
 
         emit Withdraw(from, to, underlyingAmount = calculateUnderlying(shareAmount));
 
-        emit log_named_uint("underlyingAmount", underlyingAmount);
-
         beforeWithdraw(underlyingAmount);
 
         underlying.safeTransfer(to, underlyingAmount);
@@ -136,7 +133,7 @@ abstract contract ERC4626 is ERC20, DSTestPlus {
 
     function calculateUnderlying(uint256 shareAmount) public view virtual returns (uint256) {
         uint256 shareSupply = totalSupply;
-        if (shareSupply == 0) return 0;
+        if (shareSupply == 0) return shareAmount;
 
         uint256 exchangeRate = totalHoldings().fdiv(shareSupply, baseUnit);
 

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -133,7 +133,6 @@ abstract contract ERC4626 is ERC20 {
 
     function calculateUnderlying(uint256 shareAmount) public view virtual returns (uint256) {
         uint256 shareSupply = totalSupply;
-
         if (shareSupply == 0) return shareAmount;
 
         uint256 exchangeRate = totalHoldings().fdiv(shareSupply, baseUnit);

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -28,7 +28,7 @@ abstract contract ERC4626 is ERC20 {
 
     /// @notice The base unit of the underlying token and hence vault.
     /// @dev Equal to 10 ** decimals. Used for fixed point arithmetic.
-    uint256 internal immutable baseUnit;
+    uint256 public immutable baseUnit;
 
     /// @notice Creates a new vault that accepts a specific underlying token.
     /// @param _underlying The ERC20 compliant token the vault should accept.
@@ -144,6 +144,6 @@ abstract contract ERC4626 is ERC20 {
 
         uint256 exchangeRate = totalUnderlying().fdiv(shareSupply, baseUnit);
 
-        return shareAmount.fmulUp(exchangeRate, baseUnit);
+        return shareAmount.fmul(exchangeRate, baseUnit);
     }
 }

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -6,7 +6,7 @@ import {SafeTransferLib} from "../utils/SafeTransferLib.sol";
 import {FixedPointMathLib} from "../utils/FixedPointMathLib.sol";
 
 /// @notice Minimal ERC4646 tokenized vault implementation.
-/// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/mixinz/ERC4626.sol)
+/// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/mixins/ERC4626.sol)
 abstract contract ERC4626 is ERC20 {
     using SafeTransferLib for ERC20;
     using FixedPointMathLib for uint256;

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.10;
 
+import {DSTestPlus} from "../test/utils/DSTestPlus.sol";
 import {ERC20} from "../tokens/ERC20.sol";
 import {SafeTransferLib} from "../utils/SafeTransferLib.sol";
 import {FixedPointMathLib} from "../utils/FixedPointMathLib.sol";
 
 /// @notice Minimal ERC4646 tokenized vault implementation.
 /// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/mixins/ERC4626.sol)
-abstract contract ERC4626 is ERC20 {
+abstract contract ERC4626 is ERC20, DSTestPlus {
     using SafeTransferLib for ERC20;
     using FixedPointMathLib for uint256;
 
@@ -102,6 +103,8 @@ abstract contract ERC4626 is ERC20 {
 
         emit Withdraw(from, to, underlyingAmount = calculateUnderlying(shareAmount));
 
+        emit log_named_uint("underlyingAmount", underlyingAmount);
+
         beforeWithdraw(underlyingAmount);
 
         underlying.safeTransfer(to, underlyingAmount);
@@ -133,7 +136,7 @@ abstract contract ERC4626 is ERC20 {
 
     function calculateUnderlying(uint256 shareAmount) public view virtual returns (uint256) {
         uint256 shareSupply = totalSupply;
-        if (shareSupply == 0) return shareAmount;
+        if (shareSupply == 0) return 0;
 
         uint256 exchangeRate = totalHoldings().fdiv(shareSupply, baseUnit);
 

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -28,7 +28,7 @@ abstract contract ERC4626 is ERC20 {
 
     /// @notice The base unit of the underlying token and hence vault.
     /// @dev Equal to 10 ** decimals. Used for fixed point arithmetic.
-    uint256 public immutable baseUnit;
+    uint256 internal immutable baseUnit;
 
     /// @notice Creates a new vault that accepts a specific underlying token.
     /// @param _underlying The ERC20 compliant token the vault should accept.

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -9,7 +9,7 @@ import {MockERC20} from "./utils/mocks/MockERC20.sol";
 import {MockERC4626} from "./utils/mocks/MockERC4626.sol";
 import {ERC4626User} from "./utils/users/ERC4626User.sol";
 
-// TODO: implement more fuzz tests
+// TODO: implement fuzz test for testMultipleMintDepositRedeemWithdraw
 // TODO: implement more complex scenario where part of the tokens are redeemed or withdrawn
 
 contract ERC4626Test is DSTestPlus {

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -11,7 +11,7 @@ import {ERC4626User} from "./utils/users/ERC4626User.sol";
 // TODO: implement fuzzing for tests where applicable
 // TODO: think of if there are any invariants and how you would implement them
 // TODO: fix mint implementation
-// TODO: implement more complex scenario where part of the tokens are redeems or withdrawn
+// TODO: implement more complex scenario where part of the tokens are redeemed or withdrawn
 
 contract ERC4626Test is DSTestPlus {
     MockERC20 underlying;

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -59,29 +59,6 @@ contract ERC4626Test is DSTestPlus {
         assertEq(underlying.balanceOf(address(this)), preDepositBal);
     }
 
-    function testSingleAtomicMintRedeem() public {
-        ERC4626User alice = new ERC4626User(vault, underlying);
-
-        uint256 aliceShareAmount = 100;
-        uint256 aliceUnderlyingAmount = 10e18;
-
-        uint256 preDepositShareBal = vault.totalSupply();
-        uint256 preDepositBal = vault.totalHoldings();
-
-        underlying.mint(address(alice), aliceUnderlyingAmount);
-        alice.approve(address(vault), aliceUnderlyingAmount);
-
-        uint256 underlyingAmount = vault.mint(address(alice), aliceShareAmount);
-
-        assertEq(vault.totalSupply(), aliceShareAmount);
-        assertEq(vault.totalHoldings(), underlyingAmount);
-
-        alice.redeem(address(alice), address(alice), aliceShareAmount);
-
-        assertEq(vault.totalSupply(), preDepositShareBal);
-        assertEq(vault.totalHoldings(), preDepositBal);
-    }
-
     function testMultipleAtomicDepositWithdraw() public {
         ERC4626User alice = new ERC4626User(vault, underlying);
         ERC4626User bob = new ERC4626User(vault, underlying);
@@ -161,6 +138,32 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.balanceOf(address(this)), 0);
         assertEq(vault.balanceOfUnderlying(address(this)), 0);
         assertEq(underlying.balanceOf(address(this)), preDepositBal);
+    }
+
+    function testSingleAtomicMintRedeem() public {
+        ERC4626User alice = new ERC4626User(vault, underlying);
+
+        uint256 aliceShareAmount = 100;
+        uint256 aliceUnderlyingAmount = 10e18;
+
+        uint256 preDepositShareBal = vault.totalSupply();
+        uint256 preDepositBal = vault.totalHoldings();
+
+        underlying.mint(address(alice), aliceUnderlyingAmount);
+        alice.approve(address(vault), aliceUnderlyingAmount);
+
+        uint256 underlyingAmount = vault.mint(address(alice), aliceShareAmount);
+
+        // Expect exchange rate of 1:1 on first mint
+        // This currently fails
+        assertEq(underlyingAmount, aliceShareAmount);
+        assertEq(vault.totalSupply(), aliceShareAmount);
+        assertEq(vault.totalHoldings(), underlyingAmount);
+
+        alice.redeem(address(alice), address(alice), aliceShareAmount);
+
+        assertEq(vault.totalSupply(), preDepositShareBal);
+        assertEq(vault.totalHoldings(), preDepositBal);
     }
 
     function testUnderlyingSharesRatio(uint256 underlyingBalance) public {

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -39,7 +39,7 @@ contract ERC4626Test is DSTestPlus {
 
     function testSingleAtomicDepositWithdraw() public {
         // TODO: make amount fuzzable, currently appears to overflow
-        uint256 underlyingAmount = 2e18; // underlyingAmount
+        uint256 underlyingAmount = 2e18;
 
         underlying.mint(address(this), underlyingAmount);
         underlying.approve(address(vault), underlyingAmount);
@@ -65,17 +65,28 @@ contract ERC4626Test is DSTestPlus {
 
     function testSingleAtomicMintWithdraw() public {
         // TODO: make amount fuzzable, currently appears to overflow
-        uint256 shareAmount = 2e18; // shareAmount
+        uint256 shareAmount = 2e18;
 
         underlying.mint(address(this), shareAmount);
         underlying.approve(address(vault), shareAmount);
+
+        uint256 preDepositBal = vault.calculateUnderlying(underlying.balanceOf(address(this)));
 
         uint256 underlyingAmount = vault.mint(address(this), shareAmount);
         assertEq(vault.calculateUnderlying(shareAmount), underlyingAmount);
         assertEq(vault.calculateShares(underlyingAmount), shareAmount);
 
         assertEq(vault.totalHoldings(), underlyingAmount);
-        // TODO: add calculateUnderlying / calculateShares checks to other test cases
+        assertEq(vault.balanceOf(address(this)), underlyingAmount);
+        assertEq(vault.balanceOfUnderlying(address(this)), underlyingAmount);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal - underlyingAmount);
+
+        vault.withdraw(address(this), address(this), underlyingAmount);
+
+        assertEq(vault.totalHoldings(), 0);
+        assertEq(vault.balanceOf(address(this)), 0);
+        assertEq(vault.balanceOfUnderlying(address(this)), 0);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal);
     }
 
     function testMultipleAtomicDepositWithdraw() public {

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -164,11 +164,19 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.totalSupply(), preMutationShareBal - aliceShareAmount);
         assertEq(vault.totalUnderlying(), preMutationBal + mutationUnderlyingAmount - aliceRedeemUnderlyingAmount);
 
-        // Bob withdraws his share balance
-        uint256 bobWithdrawUnderlyingAmount = bob.withdraw(address(bob), address(bob), bobUnderlyingAmount);
-        assertEq(bobWithdrawUnderlyingAmount, bobUnderlyingAmount + (mutationUnderlyingAmount / 3) * 2);
+        // Bob withdraws his share balance (share balance remains the same)
+        assertEq(vault.balanceOfUnderlying(address(bob)), bobUnderlyingAmount + (mutationUnderlyingAmount / 3) * 2);
+        assertEq(vault.balanceOf(address(bob)), bobShareAmount);
+        uint256 bobWithdrawShareAmount = bob.withdraw(
+            address(bob),
+            address(bob),
+            bobUnderlyingAmount + (mutationUnderlyingAmount / 3) * 2
+        );
+        assertEq(bobWithdrawShareAmount, bobShareAmount);
         assertEq(vault.balanceOf((address(bob))), 0);
         assertEq(vault.balanceOfUnderlying((address(bob))), 0);
+
+        // Alice and Bob left the vault, should be empty again
         assertEq(vault.totalSupply(), 0);
         assertEq(vault.totalUnderlying(), 0);
     }

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -8,8 +8,6 @@ import {MockERC20} from "./utils/mocks/MockERC20.sol";
 import {MockERC4626} from "./utils/mocks/MockERC4626.sol";
 import {ERC4626User} from "./utils/users/ERC4626User.sol";
 
-// dapp test -m ':ERC4626Test\.'
-
 contract ERC4626Test is DSTestPlus {
     MockERC4626 vault;
     MockERC20 underlying;
@@ -75,6 +73,23 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.balanceOf(address(this)), 0);
         assertEq(vault.balanceOfUnderlying(address(this)), 0);
         assertEq(underlying.balanceOf(address(this)), preDepositBal);
+    }
+
+    function testAtomicDepositWithdrawFrom() public {
+        // ERC4626User usr = new ERC4626User(vault, underlying);
+        // underlying.mint(address(usr), 1e18);
+        // usr.approve(address(this), 1e18);
+        // uint256 preDepositBal = underlying.balanceOf(address(this));
+        // vault.deposit(address(usr), 1e18);
+        // assertEq(vault.totalHoldings(), 1e18);
+        // assertEq(vault.balanceOf(address(this)), 1e18);
+        // assertEq(vault.balanceOfUnderlying(address(this)), 1e18);
+        // assertEq(underlying.balanceOf(address(this)), preDepositBal - 1e18);
+        // vault.withdrawFrom(address(usr), address(this), 1e18);
+    }
+
+    function testAtomicDepositRedeemFrom() public {
+        // ERC4626User usr = new ERC4626User(vault, underlying);
     }
 
     /*///////////////////////////////////////////////////////////////

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -7,7 +7,7 @@ import {MockERC20} from "./utils/mocks/MockERC20.sol";
 import {MockERC4626} from "./utils/mocks/MockERC4626.sol";
 import {ERC4626User} from "./utils/users/ERC4626User.sol";
 
-// TODO: fix mint implementation
+// TODO: implement fuzz tests
 // TODO: implement more complex scenario where part of the tokens are redeemed or withdrawn
 
 contract ERC4626Test is DSTestPlus {

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -30,10 +30,10 @@ contract ERC4626Test is DSTestPlus {
     }
 
     function testDeposit() public {
-        ERC4626User usr = new ERC4626User(vault);
+        ERC4626User usr = new ERC4626User(vault, underlying);
     }
 
     function testWithdraw() public {
-        ERC4626User usr = new ERC4626User(vault);
+        ERC4626User usr = new ERC4626User(vault, underlying);
     }
 }

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -154,14 +154,14 @@ contract ERC4626Test is DSTestPlus {
 
         uint256 underlyingAmount = alice.mint(address(alice), aliceShareAmount);
 
-        // Expect exchange rate of 1:1 on first mint
-        // This currently fails
+        // On first mint expect the ratio of shares to underlying to be 1:1
         assertEq(underlyingAmount, aliceShareAmount);
         assertEq(vault.totalSupply(), aliceShareAmount);
         assertEq(vault.totalUnderlying(), underlyingAmount);
 
         alice.redeem(address(alice), address(alice), aliceShareAmount);
 
+        assertEq(underlyingAmount, aliceShareAmount);
         assertEq(vault.totalSupply(), preDepositShareBal);
         assertEq(vault.totalUnderlying(), preDepositBal);
     }

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.10;
+
+import {DSTestPlus} from "./utils/DSTestPlus.sol";
+import {DSInvariantTest} from "./utils/DSInvariantTest.sol";
+
+import {MockERC20} from "./utils/mocks/MockERC20.sol";
+import {MockERC4626} from "./utils/mocks/MockERC4626.sol";
+import {ERC4626User} from "./utils/users/ERC4626User.sol";
+
+contract ERC4626Test is DSTestPlus {
+    MockERC20 underlying;
+    MockERC4626 vault;
+
+    function setUp() public {
+        underlying = new MockERC20("Token", "TKN", 18);
+        vault = new MockERC4626(underlying, "Token Vault", "vwTKN");
+    }
+
+    function invariantMetadata() public {
+        assertEq(vault.name(), "Token Vault");
+        assertEq(vault.symbol(), "vwTKN");
+        assertEq(vault.decimals(), 18);
+    }
+
+    function testMetaData() public {
+        assertEq(vault.name(), "Token Vault");
+        assertEq(vault.symbol(), "vwTKN");
+        assertEq(vault.decimals(), 18);
+    }
+
+    function testDeposit() public {
+        ERC4626User usr = new ERC4626User(vault);
+    }
+
+    function testWithdraw() public {
+        ERC4626User usr = new ERC4626User(vault);
+    }
+}

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -8,10 +8,10 @@ import {MockERC20} from "./utils/mocks/MockERC20.sol";
 import {MockERC4626} from "./utils/mocks/MockERC4626.sol";
 import {ERC4626User} from "./utils/users/ERC4626User.sol";
 
-// NOTE: dapp test -m ':ERC4626Test\.'
-// NOTE: dapp test -m ':ERC4626Test\.testMultipleAtomicDepositWithdraw'
-
 // TODO: verify hooks are being called
+// TODO: implement fuzzing for tests where applicable
+// TODO: think of if there are any invariants that must hold true
+
 contract ERC4626Test is DSTestPlus {
     MockERC4626 vault;
     MockERC20 underlying;
@@ -26,6 +26,14 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.symbol(), "vwTKN");
         assertEq(vault.decimals(), 18);
     }
+
+    // TODO: verify if this implementation is correct or giving us false trust
+    // function invariantUnderlyingSharesRatio() public {
+    //     uint256 underlyingBalance = vault.calculateUnderlying(underlying.balanceOf(address(this)));
+    //     uint256 sharesBalance = vault.calculateShares(underlying.balanceOf(address(this)));
+    //     assertEq(vault.calculateUnderlying(sharesBalance), underlyingBalance);
+    //     assertEq(vault.calculateShares(underlyingBalance), sharesBalance);
+    // }
 
     function testMetaData() public {
         assertEq(vault.name(), "Mock Token Vault");
@@ -93,6 +101,7 @@ contract ERC4626Test is DSTestPlus {
         ERC4626User alice = new ERC4626User(vault, underlying);
         ERC4626User bob = new ERC4626User(vault, underlying);
 
+        // TODO: make amount fuzzable, currently appears to overflow
         uint256 aliceUnderlyingAmount = 2e18;
         uint256 bobUnderlyingAmount = 3e18;
 

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -59,20 +59,27 @@ contract ERC4626Test is DSTestPlus {
         assertEq(underlying.balanceOf(address(this)), preDepositBal);
     }
 
-    function testSingleAtomicMintWithdraw() public {
-        // TODO: make amount fuzzable, currently appears to overflow
-        uint256 shareAmount = 2e18;
+    function testSingleAtomicMintRedeem() public {
+        ERC4626User alice = new ERC4626User(vault, underlying);
 
-        underlying.mint(address(this), 10e18);
-        underlying.approve(address(vault), 10e18);
+        uint256 aliceShareAmount = 100;
+        uint256 aliceUnderlyingAmount = 10e18;
 
-        uint256 underlyingAmount = vault.mint(address(this), shareAmount);
-        emit log_named_uint("underlyingAmount ", underlyingAmount); // -> returns 0?
+        uint256 preDepositShareBal = vault.totalSupply();
+        uint256 preDepositBal = vault.totalHoldings();
 
+        underlying.mint(address(alice), aliceUnderlyingAmount);
+        alice.approve(address(vault), aliceUnderlyingAmount);
+
+        uint256 underlyingAmount = vault.mint(address(alice), aliceShareAmount);
+
+        assertEq(vault.totalSupply(), aliceShareAmount);
         assertEq(vault.totalHoldings(), underlyingAmount);
-        emit log_named_uint("totalHoldings ", vault.totalHoldings()); // -> returns 0?
 
-        // TODO: implement withdraw
+        alice.redeem(address(alice), address(alice), aliceShareAmount);
+
+        assertEq(vault.totalSupply(), preDepositShareBal);
+        assertEq(vault.totalHoldings(), preDepositBal);
     }
 
     function testMultipleAtomicDepositWithdraw() public {

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -67,10 +67,10 @@ contract ERC4626Test is DSTestPlus {
         underlying.approve(address(vault), 10e18);
 
         uint256 underlyingAmount = vault.mint(address(this), shareAmount);
-        emit log_named_uint("underlyingAmount ", underlyingAmount);
+        emit log_named_uint("underlyingAmount ", underlyingAmount); // -> returns 0?
 
         assertEq(vault.totalHoldings(), underlyingAmount);
-        emit log_named_uint("totalHoldings ", vault.totalHoldings());
+        emit log_named_uint("totalHoldings ", vault.totalHoldings()); // -> returns 0?
 
         // TODO: implement withdraw
     }

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -51,7 +51,7 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.calculateShares(aliceUnderlyingAmount), aliceShareAmount);
         assertEq(vault.totalSupply(), aliceShareAmount);
         assertEq(vault.totalUnderlying(), aliceUnderlyingAmount);
-        assertEq(vault.balanceOf(address(alice)), aliceUnderlyingAmount);
+        assertEq(vault.balanceOf(address(alice)), aliceShareAmount);
         assertEq(vault.balanceOfUnderlying(address(alice)), aliceUnderlyingAmount);
         assertEq(underlying.balanceOf(address(alice)), alicePreDepositBal - aliceUnderlyingAmount);
 

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -97,7 +97,7 @@ contract ERC4626Test is DSTestPlus {
         assertEq(underlying.balanceOf(address(alice)), alicePreDepositBal);
     }
 
-    function testMultipleAtomicScenario() public {
+    function testMultipleMintDepositRedeemWithdraw() public {
         // Scenario:
         // - Alice mints 2e18 tokens
         // - Bob deposits 4e18 tokens

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -55,4 +55,66 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.balanceOfUnderlying(address(this)), 0);
         assertEq(underlying.balanceOf(address(this)), preDepositBal);
     }
+
+    function testAtomicDepositRedeem() public {
+        underlying.mint(address(this), 1e18);
+        underlying.approve(address(vault), 1e18);
+
+        uint256 preDepositBal = underlying.balanceOf(address(this));
+
+        vault.deposit(address(this), 1e18);
+
+        assertEq(vault.totalHoldings(), 1e18);
+        assertEq(vault.balanceOf(address(this)), 1e18);
+        assertEq(vault.balanceOfUnderlying(address(this)), 1e18);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal - 1e18);
+
+        vault.redeem(address(this), 1e18);
+
+        assertEq(vault.totalHoldings(), 0);
+        assertEq(vault.balanceOf(address(this)), 0);
+        assertEq(vault.balanceOfUnderlying(address(this)), 0);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal);
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                 DEPOSIT/WITHDRAWAL SANITY CHECK TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    function testFailDepositWithNotEnoughApproval() public {
+        underlying.mint(address(this), 0.5e18);
+        underlying.approve(address(vault), 0.5e18);
+
+        vault.deposit(address(this), 1e18);
+    }
+
+    function testFailWithdrawWithNotEnoughBalance() public {
+        underlying.mint(address(this), 0.5e18);
+        underlying.approve(address(vault), 0.5e18);
+
+        vault.deposit(address(this), 0.5e18);
+
+        vault.withdraw(address(this), 1e18);
+    }
+
+    function testFailRedeemWithNotEnoughBalance() public {
+        underlying.mint(address(this), 0.5e18);
+        underlying.approve(address(vault), 0.5e18);
+
+        vault.deposit(address(this), 0.5e18);
+
+        vault.redeem(address(this), 1e18);
+    }
+
+    function testFailRedeemWithNoBalance() public {
+        vault.redeem(address(this), 1e18);
+    }
+
+    function testFailWithdrawWithNoBalance() public {
+        vault.withdraw(address(this), 1e18);
+    }
+
+    function testFailDepositWithNoApproval() public {
+        vault.deposit(address(this), 1e18);
+    }
 }

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -33,7 +33,7 @@ contract ERC4626Test is DSTestPlus {
                         DEPOSIT/WITHDRAWAL TESTS
     //////////////////////////////////////////////////////////////*/
 
-    function testAtomicDepositWithdraw() public {
+    function testSingleAtomicDepositWithdraw() public {
         // uint256 amount = fuzzAmount / 10**underlying.decimals();
         uint256 amount = 2e18;
 
@@ -57,29 +57,68 @@ contract ERC4626Test is DSTestPlus {
         assertEq(underlying.balanceOf(address(this)), preDepositBal);
     }
 
-    function testAtomicDepositRedeem() public {
-        // uint256 amount = fuzzAmount / 10**underlying.decimals();
-        uint256 amount = 2e18;
+    // dapp test -m ':ERC4626Test\.testMultipleAtomicDepositWithdraw' --verbosity 3
+    function testMultipleAtomicDepositWithdraw() public {
+        ERC4626User alice = new ERC4626User(vault, underlying);
+        ERC4626User bob = new ERC4626User(vault, underlying);
 
-        underlying.mint(address(this), amount);
-        underlying.approve(address(vault), amount);
+        uint256 aliceAmount = 2e18;
+        uint256 bobAmount = 3e18;
 
-        uint256 preDepositBal = underlying.balanceOf(address(this));
+        underlying.mint(address(alice), aliceAmount);
+        alice.approve(address(vault), aliceAmount);
 
-        vault.deposit(address(this), amount);
+        underlying.mint(address(bob), bobAmount);
+        bob.approve(address(vault), bobAmount);
 
-        assertEq(vault.totalHoldings(), amount);
-        assertEq(vault.balanceOf(address(this)), amount);
-        assertEq(vault.balanceOfUnderlying(address(this)), amount);
-        assertEq(underlying.balanceOf(address(this)), preDepositBal - amount);
+        uint256 alicePreDepositBal = underlying.balanceOf(address(alice));
+        uint256 bobPreDepositBal = underlying.balanceOf(address(bob));
 
-        vault.redeem(address(this), address(this), amount);
+        assertEq(alicePreDepositBal, aliceAmount);
+        assertEq(bobPreDepositBal, bobAmount);
+        assertEq(underlying.allowance(address(alice), address(vault)), aliceAmount);
+        assertEq(underlying.allowance(address(bob), address(vault)), bobAmount);
 
-        assertEq(vault.totalHoldings(), 0);
-        assertEq(vault.balanceOf(address(this)), 0);
-        assertEq(vault.balanceOfUnderlying(address(this)), 0);
-        assertEq(underlying.balanceOf(address(this)), preDepositBal);
+        uint256 aliceShares = alice.deposit(address(alice), aliceAmount);
+        assertEq(aliceShares, aliceAmount);
+
+        assertEq(vault.totalHoldings(), aliceAmount);
+        assertEq(vault.balanceOf(address(alice)), aliceAmount);
+        assertEq(vault.balanceOfUnderlying(address(alice)), aliceAmount);
+        assertEq(underlying.balanceOf(address(alice)), alicePreDepositBal - aliceAmount);
+
+        uint256 bobShares = bob.deposit(address(bob), bobAmount);
+        assertEq(bobShares, bobAmount);
+
+        assertEq(vault.totalHoldings(), aliceAmount + bobAmount);
+        assertEq(vault.balanceOf(address(bob)), bobAmount);
+        assertEq(vault.balanceOfUnderlying(address(bob)), bobAmount);
+        assertEq(underlying.balanceOf(address(bob)), bobPreDepositBal - bobAmount);
     }
+
+    // function testSingleAtomicDepositRedeem() public {
+    //     // uint256 amount = fuzzAmount / 10**underlying.decimals();
+    //     uint256 amount = 2e18;
+
+    //     underlying.mint(address(this), amount);
+    //     underlying.approve(address(vault), amount);
+
+    //     uint256 preDepositBal = underlying.balanceOf(address(this));
+
+    //     vault.deposit(address(this), amount);
+
+    //     assertEq(vault.totalHoldings(), amount);
+    //     assertEq(vault.balanceOf(address(this)), amount);
+    //     assertEq(vault.balanceOfUnderlying(address(this)), amount);
+    //     assertEq(underlying.balanceOf(address(this)), preDepositBal - amount);
+
+    //     vault.redeem(address(this), address(this), amount);
+
+    //     assertEq(vault.totalHoldings(), 0);
+    //     assertEq(vault.balanceOf(address(this)), 0);
+    //     assertEq(vault.balanceOfUnderlying(address(this)), 0);
+    //     assertEq(underlying.balanceOf(address(this)), preDepositBal);
+    // }
 
     /*///////////////////////////////////////////////////////////////
                  DEPOSIT/WITHDRAWAL SANITY CHECK TESTS
@@ -88,6 +127,7 @@ contract ERC4626Test is DSTestPlus {
     function testFailDepositWithNotEnoughApproval() public {
         underlying.mint(address(this), 0.5e18);
         underlying.approve(address(vault), 0.5e18);
+        assertEq(underlying.allowance(address(this), address(vault)), 0.5e18);
 
         vault.deposit(address(this), 1e18);
     }

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -15,9 +15,12 @@ contract ERC4626Test is DSTestPlus {
     MockERC20 underlying;
     MockERC4626 vault;
 
+    uint256 private baseUnit;
+
     function setUp() public {
         underlying = new MockERC20("Mock Token", "TKN", 18);
         vault = new MockERC4626(underlying, "Mock Token Vault", "vwTKN");
+        baseUnit = 10**vault.decimals();
     }
 
     function invariantMetadata() public {
@@ -37,7 +40,6 @@ contract ERC4626Test is DSTestPlus {
 
         // Ignore cases where amount * baseUnit overflows.
         unchecked {
-            uint256 baseUnit = 10**vault.decimals();
             if (amount != 0 && (amount * baseUnit) / amount != baseUnit) return;
         }
 
@@ -78,7 +80,6 @@ contract ERC4626Test is DSTestPlus {
 
         // Ignore cases where amount * baseUnit overflows.
         unchecked {
-            uint256 baseUnit = 10**vault.decimals();
             if (amount != 0 && (amount * baseUnit) / amount != baseUnit) return;
         }
 

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -34,7 +34,7 @@ contract ERC4626Test is DSTestPlus {
     //////////////////////////////////////////////////////////////*/
 
     function testSingleAtomicDepositWithdraw() public {
-        // uint256 amount = fuzzAmount / 10**underlying.decimals();
+        // TODO: make amount fuzzable, currently appears to overflow
         uint256 amount = 2e18;
 
         underlying.mint(address(this), amount);
@@ -94,31 +94,45 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.balanceOf(address(bob)), bobAmount);
         assertEq(vault.balanceOfUnderlying(address(bob)), bobAmount);
         assertEq(underlying.balanceOf(address(bob)), bobPreDepositBal - bobAmount);
+
+        alice.withdraw(address(alice), address(alice), aliceAmount);
+
+        assertEq(vault.totalHoldings(), bobAmount);
+        assertEq(vault.balanceOf(address(alice)), 0);
+        assertEq(vault.balanceOfUnderlying(address(alice)), 0);
+        assertEq(underlying.balanceOf(address(alice)), alicePreDepositBal);
+
+        bob.withdraw(address(bob), address(bob), bobAmount);
+
+        assertEq(vault.totalHoldings(), 0);
+        assertEq(vault.balanceOf(address(bob)), 0);
+        assertEq(vault.balanceOfUnderlying(address(bob)), 0);
+        assertEq(underlying.balanceOf(address(bob)), bobPreDepositBal);
     }
 
-    // function testSingleAtomicDepositRedeem() public {
-    //     // uint256 amount = fuzzAmount / 10**underlying.decimals();
-    //     uint256 amount = 2e18;
+    function testSingleAtomicDepositRedeem() public {
+        // TODO: make amount fuzzable, currently appears to overflow
+        uint256 amount = 2e18;
 
-    //     underlying.mint(address(this), amount);
-    //     underlying.approve(address(vault), amount);
+        underlying.mint(address(this), amount);
+        underlying.approve(address(vault), amount);
 
-    //     uint256 preDepositBal = underlying.balanceOf(address(this));
+        uint256 preDepositBal = underlying.balanceOf(address(this));
 
-    //     vault.deposit(address(this), amount);
+        vault.deposit(address(this), amount);
 
-    //     assertEq(vault.totalHoldings(), amount);
-    //     assertEq(vault.balanceOf(address(this)), amount);
-    //     assertEq(vault.balanceOfUnderlying(address(this)), amount);
-    //     assertEq(underlying.balanceOf(address(this)), preDepositBal - amount);
+        assertEq(vault.totalHoldings(), amount);
+        assertEq(vault.balanceOf(address(this)), amount);
+        assertEq(vault.balanceOfUnderlying(address(this)), amount);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal - amount);
 
-    //     vault.redeem(address(this), address(this), amount);
+        vault.redeem(address(this), address(this), amount);
 
-    //     assertEq(vault.totalHoldings(), 0);
-    //     assertEq(vault.balanceOf(address(this)), 0);
-    //     assertEq(vault.balanceOfUnderlying(address(this)), 0);
-    //     assertEq(underlying.balanceOf(address(this)), preDepositBal);
-    // }
+        assertEq(vault.totalHoldings(), 0);
+        assertEq(vault.balanceOf(address(this)), 0);
+        assertEq(vault.balanceOfUnderlying(address(this)), 0);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal);
+    }
 
     /*///////////////////////////////////////////////////////////////
                  DEPOSIT/WITHDRAWAL SANITY CHECK TESTS

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -62,17 +62,18 @@ contract ERC4626Test is DSTestPlus {
         assertEq(underlying.balanceOf(address(this)), preDepositBal);
     }
 
-    // function testSingleAtomicMintWithdraw() public {
-    //     // TODO: make amount fuzzable, currently appears to overflow
-    //     uint256 shareAmount = 2e18; // shareAmount
+    function testSingleAtomicMintWithdraw() public {
+        // TODO: make amount fuzzable, currently appears to overflow
+        uint256 shareAmount = 2e18; // shareAmount
 
-    //     underlying.mint(address(this), shareAmount);
-    //     underlying.approve(address(vault), shareAmount);
+        underlying.mint(address(this), shareAmount);
+        underlying.approve(address(vault), shareAmount);
 
-    //     // // Mint requires the returned amount
-    //     uint256 underlyingAmount = vault.mint(address(this), shareAmount);
-    //     assertEq(vault.totalHoldings(), underlyingAmount);
-    // }
+        // // Mint requires the returned amount
+        uint256 underlyingAmount = vault.mint(address(this), shareAmount);
+        assertEq(underlyingAmount, shareAmount);
+        assertEq(vault.totalHoldings(), underlyingAmount);
+    }
 
     function testMultipleAtomicDepositWithdraw() public {
         ERC4626User alice = new ERC4626User(vault, underlying);

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -10,7 +10,7 @@ import {ERC4626User} from "./utils/users/ERC4626User.sol";
 
 // TODO: verify hooks are being called
 // TODO: implement fuzzing for tests where applicable
-// TODO: think of if there are any invariants that must hold true
+// TODO: think of if there are any invariants that must hold true (underlying / shares?)
 
 contract ERC4626Test is DSTestPlus {
     MockERC4626 vault;

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -69,10 +69,12 @@ contract ERC4626Test is DSTestPlus {
         underlying.mint(address(this), shareAmount);
         underlying.approve(address(vault), shareAmount);
 
-        // // Mint requires the returned amount
         uint256 underlyingAmount = vault.mint(address(this), shareAmount);
-        assertEq(underlyingAmount, shareAmount);
         assertEq(vault.totalHoldings(), underlyingAmount);
+        assertEq(vault.calculateUnderlying(shareAmount), underlyingAmount);
+        assertEq(vault.calculateShares(underlyingAmount), shareAmount);
+
+        // TODO: add calculateUnderlying / calculateShares checks to other test cases
     }
 
     function testMultipleAtomicDepositWithdraw() public {

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -239,4 +239,8 @@ contract ERC4626Test is DSTestPlus {
     function testFailDepositWithNoApproval() public {
         vault.deposit(address(this), 1e18);
     }
+
+    function testFailMintWithNoApproval() public {
+        vault.mint(address(this), 1e18);
+    }
 }

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -46,14 +46,14 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.calculateUnderlying(shareAmount), underlyingAmount);
         assertEq(vault.calculateShares(underlyingAmount), shareAmount);
 
-        assertEq(vault.totalHoldings(), underlyingAmount);
+        assertEq(vault.totalUnderlying(), underlyingAmount);
         assertEq(vault.balanceOf(address(this)), underlyingAmount);
         assertEq(vault.balanceOfUnderlying(address(this)), underlyingAmount);
         assertEq(underlying.balanceOf(address(this)), preDepositBal - underlyingAmount);
 
         vault.withdraw(address(this), address(this), underlyingAmount);
 
-        assertEq(vault.totalHoldings(), 0);
+        assertEq(vault.totalUnderlying(), 0);
         assertEq(vault.balanceOf(address(this)), 0);
         assertEq(vault.balanceOfUnderlying(address(this)), 0);
         assertEq(underlying.balanceOf(address(this)), preDepositBal);
@@ -85,7 +85,7 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.calculateUnderlying(aliceShareAmount), aliceUnderlyingAmount);
         assertEq(vault.calculateShares(aliceUnderlyingAmount), aliceShareAmount);
 
-        assertEq(vault.totalHoldings(), aliceUnderlyingAmount);
+        assertEq(vault.totalUnderlying(), aliceUnderlyingAmount);
         assertEq(vault.balanceOf(address(alice)), aliceUnderlyingAmount);
         assertEq(vault.balanceOfUnderlying(address(alice)), aliceUnderlyingAmount);
         assertEq(underlying.balanceOf(address(alice)), alicePreDepositBal - aliceUnderlyingAmount);
@@ -94,21 +94,21 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.calculateUnderlying(bobShareAmount), bobUnderlyingAmount);
         assertEq(vault.calculateShares(bobUnderlyingAmount), bobShareAmount);
 
-        assertEq(vault.totalHoldings(), aliceUnderlyingAmount + bobUnderlyingAmount);
+        assertEq(vault.totalUnderlying(), aliceUnderlyingAmount + bobUnderlyingAmount);
         assertEq(vault.balanceOf(address(bob)), bobUnderlyingAmount);
         assertEq(vault.balanceOfUnderlying(address(bob)), bobUnderlyingAmount);
         assertEq(underlying.balanceOf(address(bob)), bobPreDepositBal - bobUnderlyingAmount);
 
         alice.withdraw(address(alice), address(alice), aliceUnderlyingAmount);
 
-        assertEq(vault.totalHoldings(), bobUnderlyingAmount);
+        assertEq(vault.totalUnderlying(), bobUnderlyingAmount);
         assertEq(vault.balanceOf(address(alice)), 0);
         assertEq(vault.balanceOfUnderlying(address(alice)), 0);
         assertEq(underlying.balanceOf(address(alice)), alicePreDepositBal);
 
         bob.withdraw(address(bob), address(bob), bobUnderlyingAmount);
 
-        assertEq(vault.totalHoldings(), 0);
+        assertEq(vault.totalUnderlying(), 0);
         assertEq(vault.balanceOf(address(bob)), 0);
         assertEq(vault.balanceOfUnderlying(address(bob)), 0);
         assertEq(underlying.balanceOf(address(bob)), bobPreDepositBal);
@@ -127,14 +127,14 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.calculateUnderlying(shareAmount), underlyingAmount);
         assertEq(vault.calculateShares(underlyingAmount), shareAmount);
 
-        assertEq(vault.totalHoldings(), underlyingAmount);
+        assertEq(vault.totalUnderlying(), underlyingAmount);
         assertEq(vault.balanceOf(address(this)), underlyingAmount);
         assertEq(vault.balanceOfUnderlying(address(this)), underlyingAmount);
         assertEq(underlying.balanceOf(address(this)), preDepositBal - underlyingAmount);
 
         vault.redeem(address(this), address(this), underlyingAmount);
 
-        assertEq(vault.totalHoldings(), 0);
+        assertEq(vault.totalUnderlying(), 0);
         assertEq(vault.balanceOf(address(this)), 0);
         assertEq(vault.balanceOfUnderlying(address(this)), 0);
         assertEq(underlying.balanceOf(address(this)), preDepositBal);
@@ -147,23 +147,23 @@ contract ERC4626Test is DSTestPlus {
         uint256 aliceUnderlyingAmount = 10e18;
 
         uint256 preDepositShareBal = vault.totalSupply();
-        uint256 preDepositBal = vault.totalHoldings();
+        uint256 preDepositBal = vault.totalUnderlying();
 
         underlying.mint(address(alice), aliceUnderlyingAmount);
         alice.approve(address(vault), aliceUnderlyingAmount);
 
-        uint256 underlyingAmount = vault.mint(address(alice), aliceShareAmount);
+        uint256 underlyingAmount = alice.mint(address(alice), aliceShareAmount);
 
         // Expect exchange rate of 1:1 on first mint
         // This currently fails
         assertEq(underlyingAmount, aliceShareAmount);
         assertEq(vault.totalSupply(), aliceShareAmount);
-        assertEq(vault.totalHoldings(), underlyingAmount);
+        assertEq(vault.totalUnderlying(), underlyingAmount);
 
         alice.redeem(address(alice), address(alice), aliceShareAmount);
 
         assertEq(vault.totalSupply(), preDepositShareBal);
-        assertEq(vault.totalHoldings(), preDepositBal);
+        assertEq(vault.totalUnderlying(), preDepositBal);
     }
 
     function testUnderlyingSharesRatio(uint256 underlyingBalance) public {

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -174,10 +174,10 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.totalUnderlying(), preMutationBal);
 
         // Simulate a positive mutation (+3e18) within the vault.
-        // The vault now contains more tokens than deposited which causes the exchangeRatio to change.
+        // The vault now contains more tokens than deposited which causes the exchange rate to change.
         // Alice share is 33.33% of the vault, Bob 66.66% of the vault.
         // Alice's share count stays the same but the underlying amount changes from 2e18 to 3e18.
-        // Bob's share count stays the same but the underlying amount changes from 4e18 to 6e183.
+        // Bob's share count stays the same but the underlying amount changes from 4e18 to 6e18.
         underlying.mint(address(vault), mutationUnderlyingAmount);
         assertEq(vault.totalSupply(), preMutationShareBal);
         assertEq(vault.totalUnderlying(), preMutationBal + mutationUnderlyingAmount);

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -55,19 +55,25 @@ contract ERC4626Test is DSTestPlus {
     }
 
     function testAtomicDepositRedeem() public {
-        // underlying.mint(address(this), 1e18);
-        // underlying.approve(address(vault), 1e18);
-        // uint256 preDepositBal = underlying.balanceOf(address(this));
-        // vault.deposit(address(this), 1e18);
-        // assertEq(vault.totalHoldings(), 1e18);
-        // assertEq(vault.balanceOf(address(this)), 1e18);
-        // assertEq(vault.balanceOfUnderlying(address(this)), 1e18);
-        // assertEq(underlying.balanceOf(address(this)), preDepositBal - 1e18);
-        // vault.redeem(address(this), 1e18);
-        // assertEq(vault.totalHoldings(), 0);
-        // assertEq(vault.balanceOf(address(this)), 0);
-        // assertEq(vault.balanceOfUnderlying(address(this)), 0);
-        // assertEq(underlying.balanceOf(address(this)), preDepositBal);
+        underlying.mint(address(this), 2e18);
+        underlying.approve(address(vault), 2e18);
+
+        uint256 preDepositBal = underlying.balanceOf(address(this));
+
+        vault.deposit(address(this), 2e18);
+
+        assertEq(vault.totalHoldings(), 2e18);
+        assertEq(vault.balanceOf(address(this)), 2e18);
+        assertEq(vault.balanceOfUnderlying(address(this)), 2e18);
+
+        assertEq(underlying.balanceOf(address(this)), preDepositBal - 2e18);
+
+        vault.redeem(address(this), address(this), 2e18);
+
+        assertEq(vault.totalHoldings(), 0);
+        assertEq(vault.balanceOf(address(this)), 0);
+        assertEq(vault.balanceOfUnderlying(address(this)), 0);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal);
     }
 
     /*///////////////////////////////////////////////////////////////

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -34,19 +34,19 @@ contract ERC4626Test is DSTestPlus {
     //////////////////////////////////////////////////////////////*/
 
     function testAtomicDepositWithdraw() public {
-        underlying.mint(address(this), 1e18);
-        underlying.approve(address(vault), 1e18);
+        underlying.mint(address(this), 2e18);
+        underlying.approve(address(vault), 2e18);
 
         uint256 preDepositBal = underlying.balanceOf(address(this));
 
-        vault.deposit(address(this), 1e18);
+        vault.deposit(address(this), 2e18);
 
-        assertEq(vault.totalHoldings(), 1e18);
-        assertEq(vault.balanceOf(address(this)), 1e18);
-        assertEq(vault.balanceOfUnderlying(address(this)), 1e18);
-        assertEq(underlying.balanceOf(address(this)), preDepositBal - 1e18);
+        assertEq(vault.totalHoldings(), 2e18);
+        assertEq(vault.balanceOf(address(this)), 2e18);
+        assertEq(vault.balanceOfUnderlying(address(this)), 2e18);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal - 2e18);
 
-        vault.withdraw(address(this), 1e18);
+        vault.withdraw(address(this), address(this), 2e18);
 
         assertEq(vault.totalHoldings(), 0);
         assertEq(vault.balanceOf(address(this)), 0);
@@ -55,41 +55,19 @@ contract ERC4626Test is DSTestPlus {
     }
 
     function testAtomicDepositRedeem() public {
-        underlying.mint(address(this), 1e18);
-        underlying.approve(address(vault), 1e18);
-
-        uint256 preDepositBal = underlying.balanceOf(address(this));
-
-        vault.deposit(address(this), 1e18);
-
-        assertEq(vault.totalHoldings(), 1e18);
-        assertEq(vault.balanceOf(address(this)), 1e18);
-        assertEq(vault.balanceOfUnderlying(address(this)), 1e18);
-        assertEq(underlying.balanceOf(address(this)), preDepositBal - 1e18);
-
-        vault.redeem(address(this), 1e18);
-
-        assertEq(vault.totalHoldings(), 0);
-        assertEq(vault.balanceOf(address(this)), 0);
-        assertEq(vault.balanceOfUnderlying(address(this)), 0);
-        assertEq(underlying.balanceOf(address(this)), preDepositBal);
-    }
-
-    function testAtomicDepositWithdrawFrom() public {
-        // ERC4626User usr = new ERC4626User(vault, underlying);
-        // underlying.mint(address(usr), 1e18);
-        // usr.approve(address(this), 1e18);
+        // underlying.mint(address(this), 1e18);
+        // underlying.approve(address(vault), 1e18);
         // uint256 preDepositBal = underlying.balanceOf(address(this));
-        // vault.deposit(address(usr), 1e18);
+        // vault.deposit(address(this), 1e18);
         // assertEq(vault.totalHoldings(), 1e18);
         // assertEq(vault.balanceOf(address(this)), 1e18);
         // assertEq(vault.balanceOfUnderlying(address(this)), 1e18);
         // assertEq(underlying.balanceOf(address(this)), preDepositBal - 1e18);
-        // vault.withdrawFrom(address(usr), address(this), 1e18);
-    }
-
-    function testAtomicDepositRedeemFrom() public {
-        // ERC4626User usr = new ERC4626User(vault, underlying);
+        // vault.redeem(address(this), 1e18);
+        // assertEq(vault.totalHoldings(), 0);
+        // assertEq(vault.balanceOf(address(this)), 0);
+        // assertEq(vault.balanceOfUnderlying(address(this)), 0);
+        // assertEq(underlying.balanceOf(address(this)), preDepositBal);
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -109,7 +87,7 @@ contract ERC4626Test is DSTestPlus {
 
         vault.deposit(address(this), 0.5e18);
 
-        vault.withdraw(address(this), 1e18);
+        vault.withdraw(address(this), address(this), 1e18);
     }
 
     function testFailRedeemWithNotEnoughBalance() public {
@@ -118,15 +96,15 @@ contract ERC4626Test is DSTestPlus {
 
         vault.deposit(address(this), 0.5e18);
 
-        vault.redeem(address(this), 1e18);
+        vault.redeem(address(this), address(this), 1e18);
     }
 
     function testFailRedeemWithNoBalance() public {
-        vault.redeem(address(this), 1e18);
+        vault.redeem(address(this), address(this), 1e18);
     }
 
     function testFailWithdrawWithNoBalance() public {
-        vault.withdraw(address(this), 1e18);
+        vault.withdraw(address(this), address(this), 1e18);
     }
 
     function testFailDepositWithNoApproval() public {

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -34,19 +34,22 @@ contract ERC4626Test is DSTestPlus {
     //////////////////////////////////////////////////////////////*/
 
     function testAtomicDepositWithdraw() public {
-        underlying.mint(address(this), 2e18);
-        underlying.approve(address(vault), 2e18);
+        // uint256 amount = fuzzAmount / 10**underlying.decimals();
+        uint256 amount = 2e18;
+
+        underlying.mint(address(this), amount);
+        underlying.approve(address(vault), amount);
 
         uint256 preDepositBal = underlying.balanceOf(address(this));
 
-        vault.deposit(address(this), 2e18);
+        vault.deposit(address(this), amount);
 
-        assertEq(vault.totalHoldings(), 2e18);
-        assertEq(vault.balanceOf(address(this)), 2e18);
-        assertEq(vault.balanceOfUnderlying(address(this)), 2e18);
-        assertEq(underlying.balanceOf(address(this)), preDepositBal - 2e18);
+        assertEq(vault.totalHoldings(), amount);
+        assertEq(vault.balanceOf(address(this)), amount);
+        assertEq(vault.balanceOfUnderlying(address(this)), amount);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal - amount);
 
-        vault.withdraw(address(this), address(this), 2e18);
+        vault.withdraw(address(this), address(this), amount);
 
         assertEq(vault.totalHoldings(), 0);
         assertEq(vault.balanceOf(address(this)), 0);
@@ -55,20 +58,22 @@ contract ERC4626Test is DSTestPlus {
     }
 
     function testAtomicDepositRedeem() public {
-        underlying.mint(address(this), 2e18);
-        underlying.approve(address(vault), 2e18);
+        // uint256 amount = fuzzAmount / 10**underlying.decimals();
+        uint256 amount = 2e18;
+
+        underlying.mint(address(this), amount);
+        underlying.approve(address(vault), amount);
 
         uint256 preDepositBal = underlying.balanceOf(address(this));
 
-        vault.deposit(address(this), 2e18);
+        vault.deposit(address(this), amount);
 
-        assertEq(vault.totalHoldings(), 2e18);
-        assertEq(vault.balanceOf(address(this)), 2e18);
-        assertEq(vault.balanceOfUnderlying(address(this)), 2e18);
+        assertEq(vault.totalHoldings(), amount);
+        assertEq(vault.balanceOf(address(this)), amount);
+        assertEq(vault.balanceOfUnderlying(address(this)), amount);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal - amount);
 
-        assertEq(underlying.balanceOf(address(this)), preDepositBal - 2e18);
-
-        vault.redeem(address(this), address(this), 2e18);
+        vault.redeem(address(this), address(this), amount);
 
         assertEq(vault.totalHoldings(), 0);
         assertEq(vault.balanceOf(address(this)), 0);

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -3,8 +3,6 @@ pragma solidity 0.8.10;
 
 import {DSTestPlus} from "./utils/DSTestPlus.sol";
 
-import {FixedPointMathLib} from "../utils/FixedPointMathLib.sol";
-
 import {MockERC20} from "./utils/mocks/MockERC20.sol";
 import {MockERC4626} from "./utils/mocks/MockERC4626.sol";
 import {ERC4626User} from "./utils/users/ERC4626User.sol";
@@ -13,8 +11,6 @@ import {ERC4626User} from "./utils/users/ERC4626User.sol";
 // TODO: implement more complex scenario where part of the tokens are redeemed or withdrawn
 
 contract ERC4626Test is DSTestPlus {
-    using FixedPointMathLib for uint256;
-
     MockERC20 underlying;
     MockERC4626 vault;
 

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -66,23 +66,8 @@ contract ERC4626Test is DSTestPlus {
         underlying.mint(address(this), shareAmount);
         underlying.approve(address(vault), shareAmount);
 
-        uint256 preDepositBal = vault.calculateUnderlying(underlying.balanceOf(address(this)));
-
         uint256 underlyingAmount = vault.mint(address(this), shareAmount);
-        assertEq(vault.calculateUnderlying(shareAmount), underlyingAmount);
-        assertEq(vault.calculateShares(underlyingAmount), shareAmount);
-
-        assertEq(vault.totalHoldings(), underlyingAmount);
-        assertEq(vault.balanceOf(address(this)), underlyingAmount);
-        assertEq(vault.balanceOfUnderlying(address(this)), underlyingAmount);
-        assertEq(underlying.balanceOf(address(this)), preDepositBal - underlyingAmount);
-
-        vault.withdraw(address(this), address(this), underlyingAmount);
-
-        assertEq(vault.totalHoldings(), 0);
-        assertEq(vault.balanceOf(address(this)), 0);
-        assertEq(vault.balanceOfUnderlying(address(this)), 0);
-        assertEq(underlying.balanceOf(address(this)), preDepositBal);
+        emit log_uint(underlyingAmount); // -> returns 0
     }
 
     function testMultipleAtomicDepositWithdraw() public {

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -9,6 +9,7 @@ import {ERC4626User} from "./utils/users/ERC4626User.sol";
 
 // TODO: implement fuzz test for testMultipleMintDepositRedeemWithdraw
 // TODO: implement more complex scenario where part of the tokens are redeemed or withdrawn
+// TODO: discuss whether to make baseUnit public instead of internal
 
 contract ERC4626Test is DSTestPlus {
     MockERC20 underlying;
@@ -36,7 +37,8 @@ contract ERC4626Test is DSTestPlus {
 
         // Ignore cases where amount * baseUnit overflows.
         unchecked {
-            if (amount != 0 && (amount * vault.baseUnit()) / amount != vault.baseUnit()) return;
+            uint256 baseUnit = 10**vault.decimals();
+            if (amount != 0 && (amount * baseUnit) / amount != baseUnit) return;
         }
 
         uint256 aliceUnderlyingAmount = amount;
@@ -76,7 +78,8 @@ contract ERC4626Test is DSTestPlus {
 
         // Ignore cases where amount * baseUnit overflows.
         unchecked {
-            if (amount != 0 && (amount * vault.baseUnit()) / amount != vault.baseUnit()) return;
+            uint256 baseUnit = 10**vault.decimals();
+            if (amount != 0 && (amount * baseUnit) / amount != baseUnit) return;
         }
 
         uint256 aliceShareAmount = amount;

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -8,32 +8,51 @@ import {MockERC20} from "./utils/mocks/MockERC20.sol";
 import {MockERC4626} from "./utils/mocks/MockERC4626.sol";
 import {ERC4626User} from "./utils/users/ERC4626User.sol";
 
+// dapp test -m ':ERC4626Test\.'
+
 contract ERC4626Test is DSTestPlus {
-    MockERC20 underlying;
     MockERC4626 vault;
+    MockERC20 underlying;
 
     function setUp() public {
-        underlying = new MockERC20("Token", "TKN", 18);
-        vault = new MockERC4626(underlying, "Token Vault", "vwTKN");
+        underlying = new MockERC20("Mock Token", "TKN", 18);
+        vault = new MockERC4626(underlying, "Mock Token Vault", "vwTKN");
     }
 
     function invariantMetadata() public {
-        assertEq(vault.name(), "Token Vault");
+        assertEq(vault.name(), "Mock Token Vault");
         assertEq(vault.symbol(), "vwTKN");
         assertEq(vault.decimals(), 18);
     }
 
     function testMetaData() public {
-        assertEq(vault.name(), "Token Vault");
+        assertEq(vault.name(), "Mock Token Vault");
         assertEq(vault.symbol(), "vwTKN");
         assertEq(vault.decimals(), 18);
     }
 
-    function testDeposit() public {
-        ERC4626User usr = new ERC4626User(vault, underlying);
-    }
+    /*///////////////////////////////////////////////////////////////
+                        DEPOSIT/WITHDRAWAL TESTS
+    //////////////////////////////////////////////////////////////*/
 
-    function testWithdraw() public {
-        ERC4626User usr = new ERC4626User(vault, underlying);
+    function testAtomicDepositWithdraw() public {
+        underlying.mint(address(this), 1e18);
+        underlying.approve(address(vault), 1e18);
+
+        uint256 preDepositBal = underlying.balanceOf(address(this));
+
+        vault.deposit(address(this), 1e18);
+
+        assertEq(vault.totalHoldings(), 1e18);
+        assertEq(vault.balanceOf(address(this)), 1e18);
+        assertEq(vault.balanceOfUnderlying(address(this)), 1e18);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal - 1e18);
+
+        vault.withdraw(address(this), 1e18);
+
+        assertEq(vault.totalHoldings(), 0);
+        assertEq(vault.balanceOf(address(this)), 0);
+        assertEq(vault.balanceOfUnderlying(address(this)), 0);
+        assertEq(underlying.balanceOf(address(this)), preDepositBal);
     }
 }

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -9,7 +9,6 @@ import {ERC4626User} from "./utils/users/ERC4626User.sol";
 
 // TODO: implement fuzz test for testMultipleMintDepositRedeemWithdraw
 // TODO: implement more complex scenario where part of the tokens are redeemed or withdrawn
-// TODO: discuss whether to make baseUnit public instead of internal
 
 contract ERC4626Test is DSTestPlus {
     MockERC20 underlying;

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -31,8 +31,8 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.decimals(), 18);
     }
 
-    function testSingleDepositWithdraw() public {
-        uint256 aliceUnderlyingAmount = 10e18;
+    function testSingleDepositWithdraw(uint256 amount) public {
+        uint256 aliceUnderlyingAmount = amount;
 
         ERC4626User alice = new ERC4626User(vault, underlying);
 
@@ -49,19 +49,19 @@ contract ERC4626Test is DSTestPlus {
         assertEq(aliceUnderlyingAmount, aliceShareAmount);
         assertEq(vault.calculateUnderlying(aliceShareAmount), aliceUnderlyingAmount);
         assertEq(vault.calculateShares(aliceUnderlyingAmount), aliceShareAmount);
-        assertEq(vault.totalSupply(), aliceShareAmount);
-        assertEq(vault.totalUnderlying(), aliceUnderlyingAmount);
-        assertEq(vault.balanceOf(address(alice)), aliceShareAmount);
-        assertEq(vault.balanceOfUnderlying(address(alice)), aliceUnderlyingAmount);
-        assertEq(underlying.balanceOf(address(alice)), alicePreDepositBal - aliceUnderlyingAmount);
+        // assertEq(vault.totalSupply(), aliceShareAmount);
+        // assertEq(vault.totalUnderlying(), aliceUnderlyingAmount);
+        // assertEq(vault.balanceOf(address(alice)), aliceShareAmount);
+        // assertEq(vault.balanceOfUnderlying(address(alice)), aliceUnderlyingAmount);
+        // assertEq(underlying.balanceOf(address(alice)), alicePreDepositBal - aliceUnderlyingAmount);
 
-        alice.withdraw(address(alice), address(alice), aliceUnderlyingAmount);
-        assertEq(vault.isBeforeWithdrawHookCalled(), 1);
+        // alice.withdraw(address(alice), address(alice), aliceUnderlyingAmount);
+        // assertEq(vault.isBeforeWithdrawHookCalled(), 1);
 
-        assertEq(vault.totalUnderlying(), 0);
-        assertEq(vault.balanceOf(address(alice)), 0);
-        assertEq(vault.balanceOfUnderlying(address(alice)), 0);
-        assertEq(underlying.balanceOf(address(alice)), alicePreDepositBal);
+        // assertEq(vault.totalUnderlying(), 0);
+        // assertEq(vault.balanceOf(address(alice)), 0);
+        // assertEq(vault.balanceOfUnderlying(address(alice)), 0);
+        // assertEq(underlying.balanceOf(address(alice)), alicePreDepositBal);
     }
 
     function testSingleMintRedeem() public {
@@ -194,12 +194,6 @@ contract ERC4626Test is DSTestPlus {
         // Alice and Bob left the vault, should be empty again
         assertEq(vault.totalSupply(), 0);
         assertEq(vault.totalUnderlying(), 0);
-    }
-
-    function testUnderlyingSharesRatio(uint256 underlyingBalance) public {
-        uint256 sharesBalance = vault.calculateShares(underlyingBalance);
-        assertEq(vault.calculateUnderlying(sharesBalance), underlyingBalance);
-        assertEq(vault.calculateShares(underlyingBalance), sharesBalance);
     }
 
     function testFailDepositWithNotEnoughApproval() public {

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -36,6 +36,13 @@ contract ERC4626Test is DSTestPlus {
     }
 
     function testSingleDepositWithdraw(uint256 amount) public {
+        if (amount == 0) amount = 1;
+
+        // Ignore cases where amount * baseUnit overflows.
+        unchecked {
+            if (amount != 0 && (amount * vault.baseUnit()) / amount != vault.baseUnit()) return;
+        }
+
         uint256 aliceUnderlyingAmount = amount;
 
         ERC4626User alice = new ERC4626User(vault, underlying);
@@ -66,6 +73,8 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.balanceOf(address(alice)), 0);
         assertEq(vault.balanceOfUnderlying(address(alice)), 0);
         assertEq(underlying.balanceOf(address(alice)), alicePreDepositBal);
+
+        emit log_named_uint("amount", amount);
     }
 
     function testSingleMintRedeem() public {

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -63,11 +63,16 @@ contract ERC4626Test is DSTestPlus {
         // TODO: make amount fuzzable, currently appears to overflow
         uint256 shareAmount = 2e18;
 
-        underlying.mint(address(this), shareAmount);
-        underlying.approve(address(vault), shareAmount);
+        underlying.mint(address(this), 10e18);
+        underlying.approve(address(vault), 10e18);
 
         uint256 underlyingAmount = vault.mint(address(this), shareAmount);
-        emit log_uint(underlyingAmount); // -> returns 0
+        emit log_named_uint("underlyingAmount ", underlyingAmount);
+
+        assertEq(vault.totalHoldings(), underlyingAmount);
+        emit log_named_uint("totalHoldings ", vault.totalHoldings());
+
+        // TODO: implement withdraw
     }
 
     function testMultipleAtomicDepositWithdraw() public {

--- a/src/test/utils/mocks/MockERC4626.sol
+++ b/src/test/utils/mocks/MockERC4626.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+import {ERC20} from "../../../tokens/ERC20.sol";
+import {ERC4626} from "../../../mixins/ERC4626.sol";
+
+contract MockERC4626 is ERC4626 {
+    constructor(
+        ERC20 _underlying,
+        string memory _name,
+        string memory _symbol
+    ) ERC4626(_underlying, _name, _symbol) {}
+}

--- a/src/test/utils/mocks/MockERC4626.sol
+++ b/src/test/utils/mocks/MockERC4626.sol
@@ -14,10 +14,6 @@ contract MockERC4626 is ERC4626 {
         string memory _symbol
     ) ERC4626(_underlying, _name, _symbol) {}
 
-    function totalHoldings() public view override returns (uint256) {
-        return underlying.balanceOf(address(this));
-    }
-
     function beforeWithdraw(uint256) internal override {
         isBeforeWithdrawHookCalled = true;
     }

--- a/src/test/utils/mocks/MockERC4626.sol
+++ b/src/test/utils/mocks/MockERC4626.sol
@@ -5,9 +5,28 @@ import {ERC20} from "../../../tokens/ERC20.sol";
 import {ERC4626} from "../../../mixins/ERC4626.sol";
 
 contract MockERC4626 is ERC4626 {
+    uint256 private _beforeWithdrawHookCalledAmount = 0;
+    uint256 private _afterDepositHookCalledAmount = 0;
+
     constructor(
         ERC20 _underlying,
         string memory _name,
         string memory _symbol
     ) ERC4626(_underlying, _name, _symbol) {}
+
+    function beforeWithdraw(uint256) internal override {
+        _beforeWithdrawHookCalledAmount++;
+    }
+
+    function afterDeposit(uint256) internal override {
+        _afterDepositHookCalledAmount++;
+    }
+
+    function isBeforeWithdrawHookCalled() public view returns (uint256 times) {
+        return _beforeWithdrawHookCalledAmount;
+    }
+
+    function isAfterDepositHookCalled() public view returns (uint256 times) {
+        return _afterDepositHookCalledAmount;
+    }
 }

--- a/src/test/utils/mocks/MockERC4626.sol
+++ b/src/test/utils/mocks/MockERC4626.sol
@@ -10,4 +10,8 @@ contract MockERC4626 is ERC4626 {
         string memory _name,
         string memory _symbol
     ) ERC4626(_underlying, _name, _symbol) {}
+
+    function totalHoldings() public view override returns (uint256) {
+        return underlying.balanceOf(address(this));
+    }
 }

--- a/src/test/utils/mocks/MockERC4626.sol
+++ b/src/test/utils/mocks/MockERC4626.sol
@@ -5,6 +5,9 @@ import {ERC20} from "../../../tokens/ERC20.sol";
 import {ERC4626} from "../../../mixins/ERC4626.sol";
 
 contract MockERC4626 is ERC4626 {
+    bool public isBeforeWithdrawHookCalled = false;
+    bool public isAfterDepositHookCalled = false;
+
     constructor(
         ERC20 _underlying,
         string memory _name,
@@ -13,5 +16,13 @@ contract MockERC4626 is ERC4626 {
 
     function totalHoldings() public view override returns (uint256) {
         return underlying.balanceOf(address(this));
+    }
+
+    function beforeWithdraw(uint256) internal override {
+        isBeforeWithdrawHookCalled = true;
+    }
+
+    function afterDeposit(uint256) internal override {
+        isAfterDepositHookCalled = true;
     }
 }

--- a/src/test/utils/mocks/MockERC4626.sol
+++ b/src/test/utils/mocks/MockERC4626.sol
@@ -5,20 +5,9 @@ import {ERC20} from "../../../tokens/ERC20.sol";
 import {ERC4626} from "../../../mixins/ERC4626.sol";
 
 contract MockERC4626 is ERC4626 {
-    bool public isBeforeWithdrawHookCalled = false;
-    bool public isAfterDepositHookCalled = false;
-
     constructor(
         ERC20 _underlying,
         string memory _name,
         string memory _symbol
     ) ERC4626(_underlying, _name, _symbol) {}
-
-    function beforeWithdraw(uint256) internal override {
-        isBeforeWithdrawHookCalled = true;
-    }
-
-    function afterDeposit(uint256) internal override {
-        isAfterDepositHookCalled = true;
-    }
 }

--- a/src/test/utils/users/ERC4626User.sol
+++ b/src/test/utils/users/ERC4626User.sol
@@ -5,11 +5,19 @@ import {ERC20} from "../../../tokens/ERC20.sol";
 import {ERC4626} from "../../../mixins/ERC4626.sol";
 
 contract ERC4626User {
-    ERC4626 vault;
+    ERC4626 token;
     ERC20 underlying;
 
-    constructor(ERC4626 _vault, ERC20 _underlying) {
-        vault = _vault;
+    constructor(ERC4626 _token, ERC20 _underlying) {
+        token = _token;
         underlying = _underlying;
+    }
+
+    function approve(address spender, uint256 amount) public virtual returns (bool) {
+        return token.approve(spender, amount);
+    }
+
+    function deposit(address to, uint256 underlyingAmount) public virtual returns (uint256 shares) {
+        return token.deposit(to, underlyingAmount);
     }
 }

--- a/src/test/utils/users/ERC4626User.sol
+++ b/src/test/utils/users/ERC4626User.sol
@@ -4,20 +4,16 @@ pragma solidity >=0.8.0;
 import {ERC20} from "../../../tokens/ERC20.sol";
 import {ERC4626} from "../../../mixins/ERC4626.sol";
 
-contract ERC4626User {
-    ERC4626 token;
-    ERC20 underlying;
+import {ERC20User} from "./ERC20User.sol";
 
-    constructor(ERC4626 _token, ERC20 _underlying) {
-        token = _token;
-        underlying = _underlying;
-    }
+contract ERC4626User is ERC20User {
+    ERC4626 vault;
 
-    function approve(address spender, uint256 amount) public virtual returns (bool) {
-        return token.approve(spender, amount);
+    constructor(ERC4626 _vault, ERC20 _token) ERC20User(_token) {
+        vault = _vault;
     }
 
     function deposit(address to, uint256 underlyingAmount) public virtual returns (uint256 shares) {
-        return token.deposit(to, underlyingAmount);
+        return vault.deposit(to, underlyingAmount);
     }
 }

--- a/src/test/utils/users/ERC4626User.sol
+++ b/src/test/utils/users/ERC4626User.sol
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity >=0.8.0;
 
+import {ERC20} from "../../../tokens/ERC20.sol";
 import {ERC4626} from "../../../mixins/ERC4626.sol";
 
 contract ERC4626User {
-    ERC4626 token;
+    ERC4626 vault;
+    ERC20 underlying;
 
-    constructor(ERC4626 _token) {
-        token = _token;
+    constructor(ERC4626 _vault, ERC20 _underlying) {
+        vault = _vault;
+        underlying = _underlying;
     }
 }

--- a/src/test/utils/users/ERC4626User.sol
+++ b/src/test/utils/users/ERC4626User.sol
@@ -24,4 +24,12 @@ contract ERC4626User is ERC20User {
     ) public virtual returns (uint256 shares) {
         return vault.withdraw(from, to, underlyingAmount);
     }
+
+    function redeem(
+        address from,
+        address to,
+        uint256 shareAmount
+    ) public virtual returns (uint256 underlyingAmount) {
+        return vault.redeem(from, to, shareAmount);
+    }
 }

--- a/src/test/utils/users/ERC4626User.sol
+++ b/src/test/utils/users/ERC4626User.sol
@@ -17,6 +17,10 @@ contract ERC4626User is ERC20User {
         return vault.deposit(to, underlyingAmount);
     }
 
+    function mint(address to, uint256 shareAmount) public virtual returns (uint256 underlyingAmount) {
+        return vault.mint(to, shareAmount);
+    }
+
     function withdraw(
         address from,
         address to,

--- a/src/test/utils/users/ERC4626User.sol
+++ b/src/test/utils/users/ERC4626User.sol
@@ -16,4 +16,12 @@ contract ERC4626User is ERC20User {
     function deposit(address to, uint256 underlyingAmount) public virtual returns (uint256 shares) {
         return vault.deposit(to, underlyingAmount);
     }
+
+    function withdraw(
+        address from,
+        address to,
+        uint256 underlyingAmount
+    ) public virtual returns (uint256 shares) {
+        return vault.withdraw(from, to, underlyingAmount);
+    }
 }

--- a/src/test/utils/users/ERC4626User.sol
+++ b/src/test/utils/users/ERC4626User.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+import {ERC4626} from "../../../mixins/ERC4626.sol";
+
+contract ERC4626User {
+    ERC4626 token;
+
+    constructor(ERC4626 _token) {
+        token = _token;
+    }
+}


### PR DESCRIPTION
This PR adds a test suite for the `ERC4626` mixin and it is based off of the spec fixes in #108.

I would love to get any feedback regarding possible improvements or extensions to the test suite.

Please note that it is blocked until https://github.com/Rari-Capital/solmate/pull/108 is merged at least, possibly until the specification is in a finalized state.

Please note that this PR may also includes unrelated commits from `main` that haven't been merged back into `next` yet. This should resolve itself automatically.

To do

- [ ] implement fuzz test for testMultipleMintDepositRedeemWithdraw
- [ ] implement more complex scenario where part of the tokens are redeemed or withdrawn