### PR TITLE
fix: limit private keys to u248

### DIFF
--- a/src/test/ERC20.t.sol
+++ b/src/test/ERC20.t.sol
@@ -287,11 +287,12 @@ contract ERC20Test is DSTestPlus {
     }
 
     function testPermit(
-        uint256 privateKey,
+        uint248 privKey,
         address to,
         uint256 amount,
         uint256 deadline
     ) public {
+        uint256 privateKey = privKey
         if (deadline < block.timestamp) deadline = block.timestamp;
         if (privateKey == 0) privateKey = 1;
 


### PR DESCRIPTION
Otherwise they can be invalid curve points since Secp256k1's Curve Order is `0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141`.
See [k256](https://docs.rs/k256/latest/src/k256/lib.rs.html#54)'s implemenation.

This was detected in Forge after we made the fuzzer smarter
https://github.com/gakonst/foundry/pull/735