### PR TITLE
👷‍♂️ Use forge in CI (#132) 

### DIFF
--- a/.github/workflows/forge-tests.yml
+++ b/.github/workflows/forge-tests.yml
@@ -1,12 +1,9 @@
 name: Forge Tests
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+
+on: [push, pull_request]
 
 jobs:
-  run-ci:
+  forge-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -16,7 +13,7 @@ jobs:
         with:
           version: nightly
 
-      - name: Install library deps
+      - name: Install dependencies
         run: forge install
 
       - name: Run forge tests

--- a/.github/workflows/forge.yml
+++ b/.github/workflows/forge.yml
@@ -1,0 +1,23 @@
+name: Forge Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  run-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Foundry
+        uses: onbjerg/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install library deps
+        run: forge install
+
+      - name: Run forge tests
+        run: forge test


### PR DESCRIPTION
As title, uses foundry-action for fast forge installation from latest nightly release.

Seems like it's found an edge case in the SSTORE2 impl?

```

Failed tests:
[FAIL. Counterexample: calldata=0x054f049600000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000000, args=[0x000000, 0, 2]] testFailWriteReadCustomBoundsOutOfRange(bytes,uint256,uint256) (runs: 102, μ: 40717, ~: 43786)
```