### PR TITLE
✅ Don't `return` in `testFail` in ERC721 fuzz test

### DIFF
--- a/src/test/ERC721.t.sol
+++ b/src/test/ERC721.t.sol
@@ -586,8 +586,7 @@ contract ERC721Test is DSTestPlus {
         uint256 id,
         address to
     ) public {
-        if (owner == address(0)) to = address(0xBEEF);
-        if (owner == address(this)) return;
+        if (owner == address(0) || owner == address(this)) to = address(0xBEEF);
 
         token.mint(owner, id);
 


### PR DESCRIPTION
If owner is `address(this)`, the call wont revert, it will return, causing this test to fail.