### PR TITLE
⚡ERC721: save SLOAD in `_burn`

### DIFF
--- a/src/tokens/ERC721.sol
+++ b/src/tokens/ERC721.sol
@@ -159,7 +159,7 @@ abstract contract ERC721 {
     function _burn(uint256 id) internal virtual {
         address owner = ownerOf[id];
 
-        require(ownerOf[id] != address(0), "NOT_MINTED");
+        require(owner != address(0), "NOT_MINTED");
 
         // Ownership check above ensures no underflow.
         unchecked {


### PR DESCRIPTION
save SLOAD in `_burn`

## Description

there is a redundant SLOAD for `ownerOf[id]` since we already alias in memory in prior step

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `dapp snapshot`?
- [x] Ran `npm run lint`?
- [x] Ran `forge test`?
- [x] Ran `dapp test`?

_Pull requests with an incomplete checklist will be thrown out._
