### PR TITLE
📝 Add leading underscore to internal functions

### DIFF
--- a/src/auth/Auth.sol
+++ b/src/auth/Auth.sol
@@ -22,12 +22,12 @@ abstract contract Auth {
     }
 
     modifier requiresAuth() {
-        require(isAuthorized(msg.sender, msg.sig), "UNAUTHORIZED");
+        require(_isAuthorized(msg.sender, msg.sig), "UNAUTHORIZED");
 
         _;
     }
 
-    function isAuthorized(address user, bytes4 functionSig) internal view virtual returns (bool) {
+    function _isAuthorized(address user, bytes4 functionSig) internal view virtual returns (bool) {
         Authority auth = authority; // Memoizing authority saves us a warm SLOAD, around 100 gas.
 
         // Checking if the caller is the owner only after calling the authority saves gas in most cases, but be

--- a/src/mixins/ERC4626.sol
+++ b/src/mixins/ERC4626.sol
@@ -54,7 +54,7 @@ abstract contract ERC4626 is ERC20 {
 
         emit Deposit(msg.sender, receiver, assets, shares);
 
-        afterDeposit(assets, shares);
+        _afterDeposit(assets, shares);
     }
 
     function mint(uint256 shares, address receiver) public virtual returns (uint256 assets) {
@@ -67,7 +67,7 @@ abstract contract ERC4626 is ERC20 {
 
         emit Deposit(msg.sender, receiver, assets, shares);
 
-        afterDeposit(assets, shares);
+        _afterDeposit(assets, shares);
     }
 
     function withdraw(
@@ -83,7 +83,7 @@ abstract contract ERC4626 is ERC20 {
             if (allowed != type(uint256).max) allowance[owner][msg.sender] = allowed - shares;
         }
 
-        beforeWithdraw(assets, shares);
+        _beforeWithdraw(assets, shares);
 
         _burn(owner, shares);
 
@@ -106,7 +106,7 @@ abstract contract ERC4626 is ERC20 {
         // Check for rounding error since we round down in previewRedeem.
         require((assets = previewRedeem(shares)) != 0, "ZERO_ASSETS");
 
-        beforeWithdraw(assets, shares);
+        _beforeWithdraw(assets, shares);
 
         _burn(owner, shares);
 
@@ -177,7 +177,7 @@ abstract contract ERC4626 is ERC20 {
                          INTERNAL HOOKS LOGIC
     //////////////////////////////////////////////////////////////*/
 
-    function beforeWithdraw(uint256 assets, uint256 shares) internal virtual {}
+    function _beforeWithdraw(uint256 assets, uint256 shares) internal virtual {}
 
-    function afterDeposit(uint256 assets, uint256 shares) internal virtual {}
+    function _afterDeposit(uint256 assets, uint256 shares) internal virtual {}
 }

--- a/src/test/utils/mocks/MockERC4626.sol
+++ b/src/test/utils/mocks/MockERC4626.sol
@@ -18,11 +18,11 @@ contract MockERC4626 is ERC4626 {
         return ERC20(asset).balanceOf(address(this));
     }
 
-    function beforeWithdraw(uint256, uint256) internal override {
+    function _beforeWithdraw(uint256, uint256) internal override {
         beforeWithdrawHookCalledCounter++;
     }
 
-    function afterDeposit(uint256, uint256) internal override {
+    function _afterDeposit(uint256, uint256) internal override {
         afterDepositHookCalledCounter++;
     }
 }


### PR DESCRIPTION
## Description

Adds leading underscore to internal functions.

- Relevant discussion: [openzeppelin#1176](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/1176)
- This convention is already followed in solmate in ERC20, ERC721, ERC155
- This would be a breaking change, but people can pin to an older commit or if possible, simply make the change in their code.

## Checklist

- [x] Ran `dapp snapshot`?
- [x] Ran `npm run lint`?
- [x] Ran `forge test`?
- [x] Ran `dapp test`?