### PR TITLE
♻️ MockERC4626: Remove unnecessary cast

### DIFF
--- a/src/test/utils/mocks/MockERC4626.sol
+++ b/src/test/utils/mocks/MockERC4626.sol
@@ -15,7 +15,7 @@ contract MockERC4626 is ERC4626 {
     ) ERC4626(_underlying, _name, _symbol) {}
 
     function totalAssets() public view override returns (uint256) {
-        return ERC20(asset).balanceOf(address(this));
+        return asset.balanceOf(address(this));
     }
 
     function beforeWithdraw(uint256, uint256) internal override {


### PR DESCRIPTION
## Description

Removed unnecessary cast to ERC20 for asset in the mock ERC4626 as it's already declared as an ERC20.

## Checklist

- [x] Ran `forge snapshot`?
- [x] Ran `npm run lint`?
- [x] Ran `forge test`?

