### PR TITLE
🥢trustless erc165 selector return

### DIFF
--- a/src/tokens/ERC1155.sol
+++ b/src/tokens/ERC1155.sol
@@ -140,7 +140,7 @@ abstract contract ERC1155 {
 
     function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
         return
-            interfaceId == 0x01ffc9a7 || // ERC165 Interface ID for ERC165
+            interfaceId == this.supportsInterface.selector || // ERC165 Interface ID for ERC165
             interfaceId == 0xd9b67a26 || // ERC165 Interface ID for ERC1155
             interfaceId == 0x0e89341c; // ERC165 Interface ID for ERC1155MetadataURI
     }

--- a/src/tokens/ERC721.sol
+++ b/src/tokens/ERC721.sol
@@ -145,7 +145,7 @@ abstract contract ERC721 {
 
     function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
         return
-            interfaceId == 0x01ffc9a7 || // ERC165 Interface ID for ERC165
+            interfaceId == this.supportsInterface.selector || // ERC165 Interface ID for ERC165
             interfaceId == 0x80ac58cd || // ERC165 Interface ID for ERC721
             interfaceId == 0x5b5e139f; // ERC165 Interface ID for ERC721Metadata
     }


### PR DESCRIPTION
make erc165 selector return more trustless

## Description

we can use `this.supportsInterface.selector` to be more readable and not require user verification of magick value

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge snapshot`?
- [x] Ran `npm run lint`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._
