### PR TITLE
✅ Change fuzz test naming convention

### DIFF
--- a/src/test/Auth.t.sol
+++ b/src/test/Auth.t.sol
@@ -104,17 +104,17 @@ contract AuthTest is DSTestPlus {
         mockAuthChild.updateFlag();
     }
 
-    function testSetOwnerAsOwner(address newOwner) public {
+    function testFuzzSetOwnerAsOwner(address newOwner) public {
         mockAuthChild.setOwner(newOwner);
         assertEq(mockAuthChild.owner(), newOwner);
     }
 
-    function testSetAuthorityAsOwner(Authority newAuthority) public {
+    function testFuzzSetAuthorityAsOwner(Authority newAuthority) public {
         mockAuthChild.setAuthority(newAuthority);
         assertEq(address(mockAuthChild.authority()), address(newAuthority));
     }
 
-    function testSetOwnerWithPermissiveAuthority(address deadOwner, address newOwner) public {
+    function testFuzzSetOwnerWithPermissiveAuthority(address deadOwner, address newOwner) public {
         if (deadOwner == address(this)) deadOwner = address(0);
 
         mockAuthChild.setAuthority(new MockAuthority(true));
@@ -122,7 +122,7 @@ contract AuthTest is DSTestPlus {
         mockAuthChild.setOwner(newOwner);
     }
 
-    function testSetAuthorityWithPermissiveAuthority(address deadOwner, Authority newAuthority) public {
+    function testFuzzSetAuthorityWithPermissiveAuthority(address deadOwner, Authority newAuthority) public {
         if (deadOwner == address(this)) deadOwner = address(0);
 
         mockAuthChild.setAuthority(new MockAuthority(true));
@@ -130,7 +130,7 @@ contract AuthTest is DSTestPlus {
         mockAuthChild.setAuthority(newAuthority);
     }
 
-    function testCallFunctionWithPermissiveAuthority(address deadOwner) public {
+    function testFuzzCallFunctionWithPermissiveAuthority(address deadOwner) public {
         if (deadOwner == address(this)) deadOwner = address(0);
 
         mockAuthChild.setAuthority(new MockAuthority(true));
@@ -138,28 +138,28 @@ contract AuthTest is DSTestPlus {
         mockAuthChild.updateFlag();
     }
 
-    function testFailSetOwnerAsNonOwner(address deadOwner, address newOwner) public {
+    function testFailFuzzSetOwnerAsNonOwner(address deadOwner, address newOwner) public {
         if (deadOwner == address(this)) deadOwner = address(0);
 
         mockAuthChild.setOwner(deadOwner);
         mockAuthChild.setOwner(newOwner);
     }
 
-    function testFailSetAuthorityAsNonOwner(address deadOwner, Authority newAuthority) public {
+    function testFailFuzzSetAuthorityAsNonOwner(address deadOwner, Authority newAuthority) public {
         if (deadOwner == address(this)) deadOwner = address(0);
 
         mockAuthChild.setOwner(deadOwner);
         mockAuthChild.setAuthority(newAuthority);
     }
 
-    function testFailCallFunctionAsNonOwner(address deadOwner) public {
+    function testFailFuzzCallFunctionAsNonOwner(address deadOwner) public {
         if (deadOwner == address(this)) deadOwner = address(0);
 
         mockAuthChild.setOwner(deadOwner);
         mockAuthChild.updateFlag();
     }
 
-    function testFailSetOwnerWithRestrictiveAuthority(address deadOwner, address newOwner) public {
+    function testFailFuzzSetOwnerWithRestrictiveAuthority(address deadOwner, address newOwner) public {
         if (deadOwner == address(this)) deadOwner = address(0);
 
         mockAuthChild.setAuthority(new MockAuthority(false));
@@ -167,7 +167,7 @@ contract AuthTest is DSTestPlus {
         mockAuthChild.setOwner(newOwner);
     }
 
-    function testFailSetAuthorityWithRestrictiveAuthority(address deadOwner, Authority newAuthority) public {
+    function testFailFuzzSetAuthorityWithRestrictiveAuthority(address deadOwner, Authority newAuthority) public {
         if (deadOwner == address(this)) deadOwner = address(0);
 
         mockAuthChild.setAuthority(new MockAuthority(false));
@@ -175,7 +175,7 @@ contract AuthTest is DSTestPlus {
         mockAuthChild.setAuthority(newAuthority);
     }
 
-    function testFailCallFunctionWithRestrictiveAuthority(address deadOwner) public {
+    function testFailFuzzCallFunctionWithRestrictiveAuthority(address deadOwner) public {
         if (deadOwner == address(this)) deadOwner = address(0);
 
         mockAuthChild.setAuthority(new MockAuthority(false));
@@ -183,7 +183,7 @@ contract AuthTest is DSTestPlus {
         mockAuthChild.updateFlag();
     }
 
-    function testFailSetOwnerAsOwnerWithOutOfOrderAuthority(address deadOwner) public {
+    function testFailFuzzSetOwnerAsOwnerWithOutOfOrderAuthority(address deadOwner) public {
         if (deadOwner == address(this)) deadOwner = address(0);
 
         mockAuthChild.setAuthority(new OutOfOrderAuthority());

--- a/src/test/CREATE3.t.sol
+++ b/src/test/CREATE3.t.sol
@@ -41,7 +41,7 @@ contract CREATE3Test is DSTestPlus {
         CREATE3.deploy(salt, type(MockAuthChild).creationCode, 0);
     }
 
-    function testDeployERC20(
+    function testFuzzDeployERC20(
         bytes32 salt,
         string calldata name,
         string calldata symbol,
@@ -58,12 +58,12 @@ contract CREATE3Test is DSTestPlus {
         assertEq(deployed.decimals(), decimals);
     }
 
-    function testFailDoubleDeploySameBytecode(bytes32 salt, bytes calldata bytecode) public {
+    function testFailFuzzDoubleDeploySameBytecode(bytes32 salt, bytes calldata bytecode) public {
         CREATE3.deploy(salt, bytecode, 0);
         CREATE3.deploy(salt, bytecode, 0);
     }
 
-    function testFailDoubleDeployDifferentBytecode(
+    function testFailFuzzDoubleDeployDifferentBytecode(
         bytes32 salt,
         bytes calldata bytecode1,
         bytes calldata bytecode2

--- a/src/test/DSTestPlus.t.sol
+++ b/src/test/DSTestPlus.t.sol
@@ -22,7 +22,7 @@ contract DSTestPlusTest is DSTestPlus {
         assertRelApproxEq(0, 0, 0);
     }
 
-    function testBound(
+    function testFuzzBound(
         uint256 num,
         uint256 min,
         uint256 max
@@ -35,7 +35,7 @@ contract DSTestPlusTest is DSTestPlus {
         assertLe(bounded, max);
     }
 
-    function testFailBoundMinBiggerThanMax(
+    function testFailFuzzBoundMinBiggerThanMax(
         uint256 num,
         uint256 min,
         uint256 max

--- a/src/test/ERC1155.t.sol
+++ b/src/test/ERC1155.t.sol
@@ -830,7 +830,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.balanceOfBatch(tos, ids);
     }
 
-    function testMintToEOA(
+    function testFuzzMintToEOA(
         address to,
         uint256 id,
         uint256 amount,
@@ -845,7 +845,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         assertEq(token.balanceOf(to, id), amount);
     }
 
-    function testMintToERC1155Recipient(
+    function testFuzzMintToERC1155Recipient(
         uint256 id,
         uint256 amount,
         bytes memory mintData
@@ -862,7 +862,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         assertBytesEq(to.mintData(), mintData);
     }
 
-    function testBatchMintToEOA(
+    function testFuzzBatchMintToEOA(
         address to,
         uint256[] memory ids,
         uint256[] memory amounts,
@@ -899,7 +899,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         }
     }
 
-    function testBatchMintToERC1155Recipient(
+    function testFuzzBatchMintToERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory mintData
@@ -939,7 +939,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         }
     }
 
-    function testBurn(
+    function testFuzzBurn(
         address to,
         uint256 id,
         uint256 mintAmount,
@@ -959,7 +959,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         assertEq(token.balanceOf(address(to), id), mintAmount - burnAmount);
     }
 
-    function testBatchBurn(
+    function testFuzzBatchBurn(
         address to,
         uint256[] memory ids,
         uint256[] memory mintAmounts,
@@ -1000,13 +1000,13 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         }
     }
 
-    function testApproveAll(address to, bool approved) public {
+    function testFuzzApproveAll(address to, bool approved) public {
         token.setApprovalForAll(to, approved);
 
         assertBoolEq(token.isApprovedForAll(address(this), to), approved);
     }
 
-    function testSafeTransferFromToEOA(
+    function testFuzzSafeTransferFromToEOA(
         uint256 id,
         uint256 mintAmount,
         bytes memory mintData,
@@ -1033,7 +1033,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         assertEq(token.balanceOf(from, id), mintAmount - transferAmount);
     }
 
-    function testSafeTransferFromToERC1155Recipient(
+    function testFuzzSafeTransferFromToERC1155Recipient(
         uint256 id,
         uint256 mintAmount,
         bytes memory mintData,
@@ -1062,7 +1062,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         assertEq(token.balanceOf(from, id), mintAmount - transferAmount);
     }
 
-    function testSafeTransferFromSelf(
+    function testFuzzSafeTransferFromSelf(
         uint256 id,
         uint256 mintAmount,
         bytes memory mintData,
@@ -1084,7 +1084,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         assertEq(token.balanceOf(address(this), id), mintAmount - transferAmount);
     }
 
-    function testSafeBatchTransferFromToEOA(
+    function testFuzzSafeBatchTransferFromToEOA(
         address to,
         uint256[] memory ids,
         uint256[] memory mintAmounts,
@@ -1135,7 +1135,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         }
     }
 
-    function testSafeBatchTransferFromToERC1155Recipient(
+    function testFuzzSafeBatchTransferFromToERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory mintAmounts,
         uint256[] memory transferAmounts,
@@ -1190,7 +1190,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         }
     }
 
-    function testBatchBalanceOf(
+    function testFuzzBatchBalanceOf(
         address[] memory tos,
         uint256[] memory ids,
         uint256[] memory amounts,
@@ -1224,7 +1224,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         }
     }
 
-    function testFailMintToZero(
+    function testFailFuzzMintToZero(
         uint256 id,
         uint256 amount,
         bytes memory data
@@ -1232,7 +1232,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.mint(address(0), id, amount, data);
     }
 
-    function testFailMintToNonERC155Recipient(
+    function testFailFuzzMintToNonERC155Recipient(
         uint256 id,
         uint256 mintAmount,
         bytes memory mintData
@@ -1240,7 +1240,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.mint(address(new NonERC1155Recipient()), id, mintAmount, mintData);
     }
 
-    function testFailMintToRevertingERC155Recipient(
+    function testFailFuzzMintToRevertingERC155Recipient(
         uint256 id,
         uint256 mintAmount,
         bytes memory mintData
@@ -1248,7 +1248,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.mint(address(new RevertingERC1155Recipient()), id, mintAmount, mintData);
     }
 
-    function testFailMintToWrongReturnDataERC155Recipient(
+    function testFailFuzzMintToWrongReturnDataERC155Recipient(
         uint256 id,
         uint256 mintAmount,
         bytes memory mintData
@@ -1256,7 +1256,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.mint(address(new RevertingERC1155Recipient()), id, mintAmount, mintData);
     }
 
-    function testFailBurnInsufficientBalance(
+    function testFailFuzzBurnInsufficientBalance(
         address to,
         uint256 id,
         uint256 mintAmount,
@@ -1269,7 +1269,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.burn(to, id, burnAmount);
     }
 
-    function testFailSafeTransferFromInsufficientBalance(
+    function testFailFuzzSafeTransferFromInsufficientBalance(
         address to,
         uint256 id,
         uint256 mintAmount,
@@ -1289,7 +1289,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.safeTransferFrom(from, to, id, transferAmount, transferData);
     }
 
-    function testFailSafeTransferFromSelfInsufficientBalance(
+    function testFailFuzzSafeTransferFromSelfInsufficientBalance(
         address to,
         uint256 id,
         uint256 mintAmount,
@@ -1303,7 +1303,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.safeTransferFrom(address(this), to, id, transferAmount, transferData);
     }
 
-    function testFailSafeTransferFromToZero(
+    function testFailFuzzSafeTransferFromToZero(
         uint256 id,
         uint256 mintAmount,
         uint256 transferAmount,
@@ -1316,7 +1316,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.safeTransferFrom(address(this), address(0), id, transferAmount, transferData);
     }
 
-    function testFailSafeTransferFromToNonERC155Recipient(
+    function testFailFuzzSafeTransferFromToNonERC155Recipient(
         uint256 id,
         uint256 mintAmount,
         uint256 transferAmount,
@@ -1329,7 +1329,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.safeTransferFrom(address(this), address(new NonERC1155Recipient()), id, transferAmount, transferData);
     }
 
-    function testFailSafeTransferFromToRevertingERC1155Recipient(
+    function testFailFuzzSafeTransferFromToRevertingERC1155Recipient(
         uint256 id,
         uint256 mintAmount,
         uint256 transferAmount,
@@ -1348,7 +1348,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         );
     }
 
-    function testFailSafeTransferFromToWrongReturnDataERC1155Recipient(
+    function testFailFuzzSafeTransferFromToWrongReturnDataERC1155Recipient(
         uint256 id,
         uint256 mintAmount,
         uint256 transferAmount,
@@ -1367,7 +1367,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         );
     }
 
-    function testFailSafeBatchTransferInsufficientBalance(
+    function testFailFuzzSafeBatchTransferInsufficientBalance(
         address to,
         uint256[] memory ids,
         uint256[] memory mintAmounts,
@@ -1408,7 +1408,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.safeBatchTransferFrom(from, to, normalizedIds, normalizedTransferAmounts, transferData);
     }
 
-    function testFailSafeBatchTransferFromToZero(
+    function testFailFuzzSafeBatchTransferFromToZero(
         uint256[] memory ids,
         uint256[] memory mintAmounts,
         uint256[] memory transferAmounts,
@@ -1446,7 +1446,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.safeBatchTransferFrom(from, address(0), normalizedIds, normalizedTransferAmounts, transferData);
     }
 
-    function testFailSafeBatchTransferFromToNonERC1155Recipient(
+    function testFailFuzzSafeBatchTransferFromToNonERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory mintAmounts,
         uint256[] memory transferAmounts,
@@ -1490,7 +1490,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         );
     }
 
-    function testFailSafeBatchTransferFromToRevertingERC1155Recipient(
+    function testFailFuzzSafeBatchTransferFromToRevertingERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory mintAmounts,
         uint256[] memory transferAmounts,
@@ -1534,7 +1534,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         );
     }
 
-    function testFailSafeBatchTransferFromToWrongReturnDataERC1155Recipient(
+    function testFailFuzzSafeBatchTransferFromToWrongReturnDataERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory mintAmounts,
         uint256[] memory transferAmounts,
@@ -1578,7 +1578,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         );
     }
 
-    function testFailSafeBatchTransferFromWithArrayLengthMismatch(
+    function testFailFuzzSafeBatchTransferFromWithArrayLengthMismatch(
         address to,
         uint256[] memory ids,
         uint256[] memory mintAmounts,
@@ -1598,7 +1598,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.safeBatchTransferFrom(from, to, ids, transferAmounts, transferData);
     }
 
-    function testFailBatchMintToZero(
+    function testFailFuzzBatchMintToZero(
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory mintData
@@ -1624,7 +1624,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.batchMint(address(0), normalizedIds, normalizedAmounts, mintData);
     }
 
-    function testFailBatchMintToNonERC1155Recipient(
+    function testFailFuzzBatchMintToNonERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory mintData
@@ -1652,7 +1652,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.batchMint(address(to), normalizedIds, normalizedAmounts, mintData);
     }
 
-    function testFailBatchMintToRevertingERC1155Recipient(
+    function testFailFuzzBatchMintToRevertingERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory mintData
@@ -1680,7 +1680,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.batchMint(address(to), normalizedIds, normalizedAmounts, mintData);
     }
 
-    function testFailBatchMintToWrongReturnDataERC1155Recipient(
+    function testFailFuzzBatchMintToWrongReturnDataERC1155Recipient(
         uint256[] memory ids,
         uint256[] memory amounts,
         bytes memory mintData
@@ -1708,7 +1708,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.batchMint(address(to), normalizedIds, normalizedAmounts, mintData);
     }
 
-    function testFailBatchMintWithArrayMismatch(
+    function testFailFuzzBatchMintWithArrayMismatch(
         address to,
         uint256[] memory ids,
         uint256[] memory amounts,
@@ -1719,7 +1719,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.batchMint(address(to), ids, amounts, mintData);
     }
 
-    function testFailBatchBurnInsufficientBalance(
+    function testFailFuzzBatchBurnInsufficientBalance(
         address to,
         uint256[] memory ids,
         uint256[] memory mintAmounts,
@@ -1751,7 +1751,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.batchBurn(to, normalizedIds, normalizedBurnAmounts);
     }
 
-    function testFailBatchBurnWithArrayLengthMismatch(
+    function testFailFuzzBatchBurnWithArrayLengthMismatch(
         address to,
         uint256[] memory ids,
         uint256[] memory mintAmounts,
@@ -1765,7 +1765,7 @@ contract ERC1155Test is DSTestPlus, ERC1155TokenReceiver {
         token.batchBurn(to, ids, burnAmounts);
     }
 
-    function testFailBalanceOfBatchWithArrayMismatch(address[] memory tos, uint256[] memory ids) public view {
+    function testFailFuzzBalanceOfBatchWithArrayMismatch(address[] memory tos, uint256[] memory ids) public view {
         if (tos.length == ids.length) revert();
 
         token.balanceOfBatch(tos, ids);

--- a/src/test/ERC20.t.sol
+++ b/src/test/ERC20.t.sol
@@ -208,7 +208,7 @@ contract ERC20Test is DSTestPlus {
         token.permit(owner, address(0xCAFE), 1e18, block.timestamp, v, r, s);
     }
 
-    function testMetadata(
+    function testFuzzMetadata(
         string calldata name,
         string calldata symbol,
         uint8 decimals
@@ -219,14 +219,14 @@ contract ERC20Test is DSTestPlus {
         assertEq(tkn.decimals(), decimals);
     }
 
-    function testMint(address from, uint256 amount) public {
+    function testFuzzMint(address from, uint256 amount) public {
         token.mint(from, amount);
 
         assertEq(token.totalSupply(), amount);
         assertEq(token.balanceOf(from), amount);
     }
 
-    function testBurn(
+    function testFuzzBurn(
         address from,
         uint256 mintAmount,
         uint256 burnAmount
@@ -240,13 +240,13 @@ contract ERC20Test is DSTestPlus {
         assertEq(token.balanceOf(from), mintAmount - burnAmount);
     }
 
-    function testApprove(address to, uint256 amount) public {
+    function testFuzzApprove(address to, uint256 amount) public {
         assertTrue(token.approve(to, amount));
 
         assertEq(token.allowance(address(this), to), amount);
     }
 
-    function testTransfer(address from, uint256 amount) public {
+    function testFuzzTransfer(address from, uint256 amount) public {
         token.mint(address(this), amount);
 
         assertTrue(token.transfer(from, amount));
@@ -260,7 +260,7 @@ contract ERC20Test is DSTestPlus {
         }
     }
 
-    function testTransferFrom(
+    function testFuzzTransferFrom(
         address to,
         uint256 approval,
         uint256 amount
@@ -288,7 +288,7 @@ contract ERC20Test is DSTestPlus {
         }
     }
 
-    function testPermit(
+    function testFuzzPermit(
         uint248 privKey,
         address to,
         uint256 amount,
@@ -317,7 +317,7 @@ contract ERC20Test is DSTestPlus {
         assertEq(token.nonces(owner), 1);
     }
 
-    function testFailBurnInsufficientBalance(
+    function testFailFuzzBurnInsufficientBalance(
         address to,
         uint256 mintAmount,
         uint256 burnAmount
@@ -328,7 +328,7 @@ contract ERC20Test is DSTestPlus {
         token.burn(to, burnAmount);
     }
 
-    function testFailTransferInsufficientBalance(
+    function testFailFuzzTransferInsufficientBalance(
         address to,
         uint256 mintAmount,
         uint256 sendAmount
@@ -339,7 +339,7 @@ contract ERC20Test is DSTestPlus {
         token.transfer(to, sendAmount);
     }
 
-    function testFailTransferFromInsufficientAllowance(
+    function testFailFuzzTransferFromInsufficientAllowance(
         address to,
         uint256 approval,
         uint256 amount
@@ -356,7 +356,7 @@ contract ERC20Test is DSTestPlus {
         token.transferFrom(from, to, amount);
     }
 
-    function testFailTransferFromInsufficientBalance(
+    function testFailFuzzTransferFromInsufficientBalance(
         address to,
         uint256 mintAmount,
         uint256 sendAmount
@@ -373,7 +373,7 @@ contract ERC20Test is DSTestPlus {
         token.transferFrom(from, to, sendAmount);
     }
 
-    function testFailPermitBadNonce(
+    function testFailFuzzPermitBadNonce(
         uint256 privateKey,
         address to,
         uint256 amount,
@@ -400,7 +400,7 @@ contract ERC20Test is DSTestPlus {
         token.permit(owner, to, amount, deadline, v, r, s);
     }
 
-    function testFailPermitBadDeadline(
+    function testFailFuzzPermitBadDeadline(
         uint256 privateKey,
         address to,
         uint256 amount,
@@ -425,7 +425,7 @@ contract ERC20Test is DSTestPlus {
         token.permit(owner, to, amount, deadline + 1, v, r, s);
     }
 
-    function testFailPermitPastDeadline(
+    function testFailFuzzPermitPastDeadline(
         uint256 privateKey,
         address to,
         uint256 amount,
@@ -450,7 +450,7 @@ contract ERC20Test is DSTestPlus {
         token.permit(owner, to, amount, deadline, v, r, s);
     }
 
-    function testFailPermitReplay(
+    function testFailFuzzPermitReplay(
         uint256 privateKey,
         address to,
         uint256 amount,

--- a/src/test/ERC4626.t.sol
+++ b/src/test/ERC4626.t.sol
@@ -21,14 +21,14 @@ contract ERC4626Test is DSTestPlus {
         assertEq(vault.decimals(), 18);
     }
 
-    function testMetadata(string calldata name, string calldata symbol) public {
+    function testFuzzMetadata(string calldata name, string calldata symbol) public {
         MockERC4626 vlt = new MockERC4626(underlying, name, symbol);
         assertEq(vlt.name(), name);
         assertEq(vlt.symbol(), symbol);
         assertEq(address(vlt.asset()), address(underlying));
     }
 
-    function testSingleDepositWithdraw(uint128 amount) public {
+    function testFuzzSingleDepositWithdraw(uint128 amount) public {
         if (amount == 0) amount = 1;
 
         uint256 aliceUnderlyingAmount = amount;
@@ -69,7 +69,7 @@ contract ERC4626Test is DSTestPlus {
         assertEq(underlying.balanceOf(alice), alicePreDepositBal);
     }
 
-    function testSingleMintRedeem(uint128 amount) public {
+    function testFuzzSingleMintRedeem(uint128 amount) public {
         if (amount == 0) amount = 1;
 
         uint256 aliceShareAmount = amount;

--- a/src/test/ERC721.t.sol
+++ b/src/test/ERC721.t.sol
@@ -368,14 +368,14 @@ contract ERC721Test is DSTestPlus {
         token.ownerOf(1337);
     }
 
-    function testMetadata(string memory name, string memory symbol) public {
+    function testFuzzMetadata(string memory name, string memory symbol) public {
         MockERC721 tkn = new MockERC721(name, symbol);
 
         assertEq(tkn.name(), name);
         assertEq(tkn.symbol(), symbol);
     }
 
-    function testMint(address to, uint256 id) public {
+    function testFuzzMint(address to, uint256 id) public {
         if (to == address(0)) to = address(0xBEEF);
 
         token.mint(to, id);
@@ -384,7 +384,7 @@ contract ERC721Test is DSTestPlus {
         assertEq(token.ownerOf(id), to);
     }
 
-    function testBurn(address to, uint256 id) public {
+    function testFuzzBurn(address to, uint256 id) public {
         if (to == address(0)) to = address(0xBEEF);
 
         token.mint(to, id);
@@ -396,7 +396,7 @@ contract ERC721Test is DSTestPlus {
         token.ownerOf(id);
     }
 
-    function testApprove(address to, uint256 id) public {
+    function testFuzzApprove(address to, uint256 id) public {
         if (to == address(0)) to = address(0xBEEF);
 
         token.mint(address(this), id);
@@ -406,7 +406,7 @@ contract ERC721Test is DSTestPlus {
         assertEq(token.getApproved(id), to);
     }
 
-    function testApproveBurn(address to, uint256 id) public {
+    function testFuzzApproveBurn(address to, uint256 id) public {
         token.mint(address(this), id);
 
         token.approve(address(to), id);
@@ -420,13 +420,13 @@ contract ERC721Test is DSTestPlus {
         token.ownerOf(id);
     }
 
-    function testApproveAll(address to, bool approved) public {
+    function testFuzzApproveAll(address to, bool approved) public {
         token.setApprovalForAll(to, approved);
 
         assertBoolEq(token.isApprovedForAll(address(this), to), approved);
     }
 
-    function testTransferFrom(uint256 id, address to) public {
+    function testFuzzTransferFrom(uint256 id, address to) public {
         address from = address(0xABCD);
 
         if (to == address(0) || to == from) to = address(0xBEEF);
@@ -444,7 +444,7 @@ contract ERC721Test is DSTestPlus {
         assertEq(token.balanceOf(from), 0);
     }
 
-    function testTransferFromSelf(uint256 id, address to) public {
+    function testFuzzTransferFromSelf(uint256 id, address to) public {
         if (to == address(0) || to == address(this)) to = address(0xBEEF);
 
         token.mint(address(this), id);
@@ -457,7 +457,7 @@ contract ERC721Test is DSTestPlus {
         assertEq(token.balanceOf(address(this)), 0);
     }
 
-    function testTransferFromApproveAll(uint256 id, address to) public {
+    function testFuzzTransferFromApproveAll(uint256 id, address to) public {
         address from = address(0xABCD);
 
         if (to == address(0) || to == from) to = address(0xBEEF);
@@ -475,7 +475,7 @@ contract ERC721Test is DSTestPlus {
         assertEq(token.balanceOf(from), 0);
     }
 
-    function testSafeTransferFromToEOA(uint256 id, address to) public {
+    function testFuzzSafeTransferFromToEOA(uint256 id, address to) public {
         address from = address(0xABCD);
 
         if (to == address(0) || to == from) to = address(0xBEEF);
@@ -495,7 +495,7 @@ contract ERC721Test is DSTestPlus {
         assertEq(token.balanceOf(from), 0);
     }
 
-    function testSafeTransferFromToERC721Recipient(uint256 id) public {
+    function testFuzzSafeTransferFromToERC721Recipient(uint256 id) public {
         address from = address(0xABCD);
 
         ERC721Recipient recipient = new ERC721Recipient();
@@ -518,7 +518,7 @@ contract ERC721Test is DSTestPlus {
         assertBytesEq(recipient.data(), "");
     }
 
-    function testSafeTransferFromToERC721RecipientWithData(uint256 id, bytes calldata data) public {
+    function testFuzzSafeTransferFromToERC721RecipientWithData(uint256 id, bytes calldata data) public {
         address from = address(0xABCD);
         ERC721Recipient recipient = new ERC721Recipient();
 
@@ -540,7 +540,7 @@ contract ERC721Test is DSTestPlus {
         assertBytesEq(recipient.data(), data);
     }
 
-    function testSafeMintToEOA(uint256 id, address to) public {
+    function testFuzzSafeMintToEOA(uint256 id, address to) public {
         if (to == address(0)) to = address(0xBEEF);
 
         if (uint256(uint160(to)) <= 18 || to.code.length > 0) return;
@@ -551,7 +551,7 @@ contract ERC721Test is DSTestPlus {
         assertEq(token.balanceOf(address(to)), 1);
     }
 
-    function testSafeMintToERC721Recipient(uint256 id) public {
+    function testFuzzSafeMintToERC721Recipient(uint256 id) public {
         ERC721Recipient to = new ERC721Recipient();
 
         token.safeMint(address(to), id);
@@ -565,7 +565,7 @@ contract ERC721Test is DSTestPlus {
         assertBytesEq(to.data(), "");
     }
 
-    function testSafeMintToERC721RecipientWithData(uint256 id, bytes calldata data) public {
+    function testFuzzSafeMintToERC721RecipientWithData(uint256 id, bytes calldata data) public {
         ERC721Recipient to = new ERC721Recipient();
 
         token.safeMint(address(to), id, data);
@@ -579,22 +579,22 @@ contract ERC721Test is DSTestPlus {
         assertBytesEq(to.data(), data);
     }
 
-    function testFailMintToZero(uint256 id) public {
+    function testFailFuzzMintToZero(uint256 id) public {
         token.mint(address(0), id);
     }
 
-    function testFailDoubleMint(uint256 id, address to) public {
+    function testFailFuzzDoubleMint(uint256 id, address to) public {
         if (to == address(0)) to = address(0xBEEF);
 
         token.mint(to, id);
         token.mint(to, id);
     }
 
-    function testFailBurnUnMinted(uint256 id) public {
+    function testFailFuzzBurnUnMinted(uint256 id) public {
         token.burn(id);
     }
 
-    function testFailDoubleBurn(uint256 id, address to) public {
+    function testFailFuzzDoubleBurn(uint256 id, address to) public {
         if (to == address(0)) to = address(0xBEEF);
 
         token.mint(to, id);
@@ -603,11 +603,11 @@ contract ERC721Test is DSTestPlus {
         token.burn(id);
     }
 
-    function testFailApproveUnMinted(uint256 id, address to) public {
+    function testFailFuzzApproveUnMinted(uint256 id, address to) public {
         token.approve(to, id);
     }
 
-    function testFailApproveUnAuthorized(
+    function testFailFuzzApproveUnAuthorized(
         address owner,
         uint256 id,
         address to
@@ -619,7 +619,7 @@ contract ERC721Test is DSTestPlus {
         token.approve(to, id);
     }
 
-    function testFailTransferFromUnOwned(
+    function testFailFuzzTransferFromUnOwned(
         address from,
         address to,
         uint256 id
@@ -627,7 +627,7 @@ contract ERC721Test is DSTestPlus {
         token.transferFrom(from, to, id);
     }
 
-    function testFailTransferFromWrongFrom(
+    function testFailFuzzTransferFromWrongFrom(
         address owner,
         address from,
         address to,
@@ -641,13 +641,13 @@ contract ERC721Test is DSTestPlus {
         token.transferFrom(from, to, id);
     }
 
-    function testFailTransferFromToZero(uint256 id) public {
+    function testFailFuzzTransferFromToZero(uint256 id) public {
         token.mint(address(this), id);
 
         token.transferFrom(address(this), address(0), id);
     }
 
-    function testFailTransferFromNotOwner(
+    function testFailFuzzTransferFromNotOwner(
         address from,
         address to,
         uint256 id
@@ -659,37 +659,37 @@ contract ERC721Test is DSTestPlus {
         token.transferFrom(from, to, id);
     }
 
-    function testFailSafeTransferFromToNonERC721Recipient(uint256 id) public {
+    function testFailFuzzSafeTransferFromToNonERC721Recipient(uint256 id) public {
         token.mint(address(this), id);
 
         token.safeTransferFrom(address(this), address(new NonERC721Recipient()), id);
     }
 
-    function testFailSafeTransferFromToNonERC721RecipientWithData(uint256 id, bytes calldata data) public {
+    function testFailFuzzSafeTransferFromToNonERC721RecipientWithData(uint256 id, bytes calldata data) public {
         token.mint(address(this), id);
 
         token.safeTransferFrom(address(this), address(new NonERC721Recipient()), id, data);
     }
 
-    function testFailSafeTransferFromToRevertingERC721Recipient(uint256 id) public {
+    function testFailFuzzSafeTransferFromToRevertingERC721Recipient(uint256 id) public {
         token.mint(address(this), id);
 
         token.safeTransferFrom(address(this), address(new RevertingERC721Recipient()), id);
     }
 
-    function testFailSafeTransferFromToRevertingERC721RecipientWithData(uint256 id, bytes calldata data) public {
+    function testFailFuzzSafeTransferFromToRevertingERC721RecipientWithData(uint256 id, bytes calldata data) public {
         token.mint(address(this), id);
 
         token.safeTransferFrom(address(this), address(new RevertingERC721Recipient()), id, data);
     }
 
-    function testFailSafeTransferFromToERC721RecipientWithWrongReturnData(uint256 id) public {
+    function testFailFuzzSafeTransferFromToERC721RecipientWithWrongReturnData(uint256 id) public {
         token.mint(address(this), id);
 
         token.safeTransferFrom(address(this), address(new WrongReturnDataERC721Recipient()), id);
     }
 
-    function testFailSafeTransferFromToERC721RecipientWithWrongReturnDataWithData(uint256 id, bytes calldata data)
+    function testFailFuzzSafeTransferFromToERC721RecipientWithWrongReturnDataWithData(uint256 id, bytes calldata data)
         public
     {
         token.mint(address(this), id);
@@ -697,31 +697,31 @@ contract ERC721Test is DSTestPlus {
         token.safeTransferFrom(address(this), address(new WrongReturnDataERC721Recipient()), id, data);
     }
 
-    function testFailSafeMintToNonERC721Recipient(uint256 id) public {
+    function testFailFuzzSafeMintToNonERC721Recipient(uint256 id) public {
         token.safeMint(address(new NonERC721Recipient()), id);
     }
 
-    function testFailSafeMintToNonERC721RecipientWithData(uint256 id, bytes calldata data) public {
+    function testFailFuzzSafeMintToNonERC721RecipientWithData(uint256 id, bytes calldata data) public {
         token.safeMint(address(new NonERC721Recipient()), id, data);
     }
 
-    function testFailSafeMintToRevertingERC721Recipient(uint256 id) public {
+    function testFailFuzzSafeMintToRevertingERC721Recipient(uint256 id) public {
         token.safeMint(address(new RevertingERC721Recipient()), id);
     }
 
-    function testFailSafeMintToRevertingERC721RecipientWithData(uint256 id, bytes calldata data) public {
+    function testFailFuzzSafeMintToRevertingERC721RecipientWithData(uint256 id, bytes calldata data) public {
         token.safeMint(address(new RevertingERC721Recipient()), id, data);
     }
 
-    function testFailSafeMintToERC721RecipientWithWrongReturnData(uint256 id) public {
+    function testFailFuzzSafeMintToERC721RecipientWithWrongReturnData(uint256 id) public {
         token.safeMint(address(new WrongReturnDataERC721Recipient()), id);
     }
 
-    function testFailSafeMintToERC721RecipientWithWrongReturnDataWithData(uint256 id, bytes calldata data) public {
+    function testFailFuzzSafeMintToERC721RecipientWithWrongReturnDataWithData(uint256 id, bytes calldata data) public {
         token.safeMint(address(new WrongReturnDataERC721Recipient()), id, data);
     }
 
-    function testFailOwnerOfUnminted(uint256 id) public view {
+    function testFailFuzzOwnerOfUnminted(uint256 id) public view {
         token.ownerOf(id);
     }
 }

--- a/src/test/FixedPointMathLib.t.sol
+++ b/src/test/FixedPointMathLib.t.sol
@@ -123,7 +123,7 @@ contract FixedPointMathLibTest is DSTestPlus {
         assertEq(FixedPointMathLib.sqrt(32239684), 5678);
     }
 
-    function testMulWadDown(uint256 x, uint256 y) public {
+    function testFuzzMulWadDown(uint256 x, uint256 y) public {
         // Ignore cases where x * y overflows.
         unchecked {
             if (x != 0 && (x * y) / x != y) return;
@@ -132,7 +132,7 @@ contract FixedPointMathLibTest is DSTestPlus {
         assertEq(FixedPointMathLib.mulWadDown(x, y), (x * y) / 1e18);
     }
 
-    function testFailMulWadDownOverflow(uint256 x, uint256 y) public pure {
+    function testFailFuzzMulWadDownOverflow(uint256 x, uint256 y) public pure {
         // Ignore cases where x * y does not overflow.
         unchecked {
             if ((x * y) / x == y) revert();
@@ -141,7 +141,7 @@ contract FixedPointMathLibTest is DSTestPlus {
         FixedPointMathLib.mulWadDown(x, y);
     }
 
-    function testMulWadUp(uint256 x, uint256 y) public {
+    function testFuzzMulWadUp(uint256 x, uint256 y) public {
         // Ignore cases where x * y overflows.
         unchecked {
             if (x != 0 && (x * y) / x != y) return;
@@ -150,7 +150,7 @@ contract FixedPointMathLibTest is DSTestPlus {
         assertEq(FixedPointMathLib.mulWadUp(x, y), x * y == 0 ? 0 : (x * y - 1) / 1e18 + 1);
     }
 
-    function testFailMulWadUpOverflow(uint256 x, uint256 y) public pure {
+    function testFailFuzzMulWadUpOverflow(uint256 x, uint256 y) public pure {
         // Ignore cases where x * y does not overflow.
         unchecked {
             if ((x * y) / x == y) revert();
@@ -159,7 +159,7 @@ contract FixedPointMathLibTest is DSTestPlus {
         FixedPointMathLib.mulWadUp(x, y);
     }
 
-    function testDivWadDown(uint256 x, uint256 y) public {
+    function testFuzzDivWadDown(uint256 x, uint256 y) public {
         // Ignore cases where x * WAD overflows or y is 0.
         unchecked {
             if (y == 0 || (x != 0 && (x * 1e18) / 1e18 != x)) return;
@@ -168,7 +168,7 @@ contract FixedPointMathLibTest is DSTestPlus {
         assertEq(FixedPointMathLib.divWadDown(x, y), (x * 1e18) / y);
     }
 
-    function testFailDivWadDownOverflow(uint256 x, uint256 y) public pure {
+    function testFailFuzzDivWadDownOverflow(uint256 x, uint256 y) public pure {
         // Ignore cases where x * WAD does not overflow or y is 0.
         unchecked {
             if (y == 0 || (x * 1e18) / 1e18 == x) revert();
@@ -177,11 +177,11 @@ contract FixedPointMathLibTest is DSTestPlus {
         FixedPointMathLib.divWadDown(x, y);
     }
 
-    function testFailDivWadDownZeroDenominator(uint256 x) public pure {
+    function testFailFuzzDivWadDownZeroDenominator(uint256 x) public pure {
         FixedPointMathLib.divWadDown(x, 0);
     }
 
-    function testDivWadUp(uint256 x, uint256 y) public {
+    function testFuzzDivWadUp(uint256 x, uint256 y) public {
         // Ignore cases where x * WAD overflows or y is 0.
         unchecked {
             if (y == 0 || (x != 0 && (x * 1e18) / 1e18 != x)) return;
@@ -190,7 +190,7 @@ contract FixedPointMathLibTest is DSTestPlus {
         assertEq(FixedPointMathLib.divWadUp(x, y), x == 0 ? 0 : (x * 1e18 - 1) / y + 1);
     }
 
-    function testFailDivWadUpOverflow(uint256 x, uint256 y) public pure {
+    function testFailFuzzDivWadUpOverflow(uint256 x, uint256 y) public pure {
         // Ignore cases where x * WAD does not overflow or y is 0.
         unchecked {
             if (y == 0 || (x * 1e18) / 1e18 == x) revert();
@@ -199,11 +199,11 @@ contract FixedPointMathLibTest is DSTestPlus {
         FixedPointMathLib.divWadUp(x, y);
     }
 
-    function testFailDivWadUpZeroDenominator(uint256 x) public pure {
+    function testFailFuzzDivWadUpZeroDenominator(uint256 x) public pure {
         FixedPointMathLib.divWadUp(x, 0);
     }
 
-    function testMulDivDown(
+    function testFuzzMulDivDown(
         uint256 x,
         uint256 y,
         uint256 denominator
@@ -216,7 +216,7 @@ contract FixedPointMathLibTest is DSTestPlus {
         assertEq(FixedPointMathLib.mulDivDown(x, y, denominator), (x * y) / denominator);
     }
 
-    function testFailMulDivDownOverflow(
+    function testFailFuzzMulDivDownOverflow(
         uint256 x,
         uint256 y,
         uint256 denominator
@@ -229,11 +229,11 @@ contract FixedPointMathLibTest is DSTestPlus {
         FixedPointMathLib.mulDivDown(x, y, denominator);
     }
 
-    function testFailMulDivDownZeroDenominator(uint256 x, uint256 y) public pure {
+    function testFailFuzzMulDivDownZeroDenominator(uint256 x, uint256 y) public pure {
         FixedPointMathLib.mulDivDown(x, y, 0);
     }
 
-    function testMulDivUp(
+    function testFuzzMulDivUp(
         uint256 x,
         uint256 y,
         uint256 denominator
@@ -246,7 +246,7 @@ contract FixedPointMathLibTest is DSTestPlus {
         assertEq(FixedPointMathLib.mulDivUp(x, y, denominator), x * y == 0 ? 0 : (x * y - 1) / denominator + 1);
     }
 
-    function testFailMulDivUpOverflow(
+    function testFailFuzzMulDivUpOverflow(
         uint256 x,
         uint256 y,
         uint256 denominator
@@ -259,11 +259,11 @@ contract FixedPointMathLibTest is DSTestPlus {
         FixedPointMathLib.mulDivUp(x, y, denominator);
     }
 
-    function testFailMulDivUpZeroDenominator(uint256 x, uint256 y) public pure {
+    function testFailFuzzMulDivUpZeroDenominator(uint256 x, uint256 y) public pure {
         FixedPointMathLib.mulDivUp(x, y, 0);
     }
 
-    function testSqrt(uint256 x) public {
+    function testFuzzSqrt(uint256 x) public {
         uint256 root = FixedPointMathLib.sqrt(x);
         uint256 next = root + 1;
 

--- a/src/test/MultiRolesAuthority.t.sol
+++ b/src/test/MultiRolesAuthority.t.sol
@@ -156,7 +156,7 @@ contract MultiRolesAuthorityTest is DSTestPlus {
         assertFalse(multiRolesAuthority.canCall(address(0xBEEF), address(0xCAFE), 0xBEEFCAFE));
     }
 
-    function testSetRoles(address user, uint8 role) public {
+    function testFuzzSetRoles(address user, uint8 role) public {
         assertFalse(multiRolesAuthority.doesUserHaveRole(user, role));
 
         multiRolesAuthority.setUserRole(user, role, true);
@@ -166,7 +166,7 @@ contract MultiRolesAuthorityTest is DSTestPlus {
         assertFalse(multiRolesAuthority.doesUserHaveRole(user, role));
     }
 
-    function testSetRoleCapabilities(uint8 role, bytes4 functionSig) public {
+    function testFuzzSetRoleCapabilities(uint8 role, bytes4 functionSig) public {
         assertFalse(multiRolesAuthority.doesRoleHaveCapability(role, functionSig));
 
         multiRolesAuthority.setRoleCapability(role, functionSig, true);
@@ -176,7 +176,7 @@ contract MultiRolesAuthorityTest is DSTestPlus {
         assertFalse(multiRolesAuthority.doesRoleHaveCapability(role, functionSig));
     }
 
-    function testSetPublicCapabilities(bytes4 functionSig) public {
+    function testFuzzSetPublicCapabilities(bytes4 functionSig) public {
         assertFalse(multiRolesAuthority.isCapabilityPublic(functionSig));
 
         multiRolesAuthority.setPublicCapability(functionSig, true);
@@ -186,7 +186,7 @@ contract MultiRolesAuthorityTest is DSTestPlus {
         assertFalse(multiRolesAuthority.isCapabilityPublic(functionSig));
     }
 
-    function testSetTargetCustomAuthority(address user, Authority customAuthority) public {
+    function testFuzzSetTargetCustomAuthority(address user, Authority customAuthority) public {
         assertEq(address(multiRolesAuthority.getTargetCustomAuthority(user)), address(0));
 
         multiRolesAuthority.setTargetCustomAuthority(user, customAuthority);
@@ -196,7 +196,7 @@ contract MultiRolesAuthorityTest is DSTestPlus {
         assertEq(address(multiRolesAuthority.getTargetCustomAuthority(user)), address(0));
     }
 
-    function testCanCallWithAuthorizedRole(
+    function testFuzzCanCallWithAuthorizedRole(
         address user,
         uint8 role,
         address target,
@@ -220,7 +220,7 @@ contract MultiRolesAuthorityTest is DSTestPlus {
         assertFalse(multiRolesAuthority.canCall(user, target, functionSig));
     }
 
-    function testCanCallPublicCapability(
+    function testFuzzCanCallPublicCapability(
         address user,
         address target,
         bytes4 functionSig
@@ -234,7 +234,7 @@ contract MultiRolesAuthorityTest is DSTestPlus {
         assertFalse(multiRolesAuthority.canCall(user, target, functionSig));
     }
 
-    function testCanCallWithCustomAuthority(
+    function testFuzzCanCallWithCustomAuthority(
         address user,
         address target,
         bytes4 functionSig
@@ -257,7 +257,7 @@ contract MultiRolesAuthorityTest is DSTestPlus {
         assertTrue(multiRolesAuthority.canCall(user, target, functionSig));
     }
 
-    function testCanCallWithCustomAuthorityOverridesPublicCapability(
+    function testFuzzCanCallWithCustomAuthorityOverridesPublicCapability(
         address user,
         address target,
         bytes4 functionSig
@@ -283,7 +283,7 @@ contract MultiRolesAuthorityTest is DSTestPlus {
         assertTrue(multiRolesAuthority.canCall(user, target, functionSig));
     }
 
-    function testCanCallWithCustomAuthorityOverridesUserWithRole(
+    function testFuzzCanCallWithCustomAuthorityOverridesUserWithRole(
         address user,
         uint8 role,
         address target,

--- a/src/test/RolesAuthority.t.sol
+++ b/src/test/RolesAuthority.t.sol
@@ -74,7 +74,7 @@ contract RolesAuthorityTest is DSTestPlus {
         assertFalse(rolesAuthority.canCall(address(0xBEEF), address(0xCAFE), 0xBEEFCAFE));
     }
 
-    function testSetRoles(address user, uint8 role) public {
+    function testFuzzSetRoles(address user, uint8 role) public {
         assertFalse(rolesAuthority.doesUserHaveRole(user, role));
 
         rolesAuthority.setUserRole(user, role, true);
@@ -84,7 +84,7 @@ contract RolesAuthorityTest is DSTestPlus {
         assertFalse(rolesAuthority.doesUserHaveRole(user, role));
     }
 
-    function testSetRoleCapabilities(
+    function testFuzzSetRoleCapabilities(
         uint8 role,
         address target,
         bytes4 functionSig
@@ -98,7 +98,7 @@ contract RolesAuthorityTest is DSTestPlus {
         assertFalse(rolesAuthority.doesRoleHaveCapability(role, target, functionSig));
     }
 
-    function testSetPublicCapabilities(address target, bytes4 functionSig) public {
+    function testFuzzSetPublicCapabilities(address target, bytes4 functionSig) public {
         assertFalse(rolesAuthority.isCapabilityPublic(target, functionSig));
 
         rolesAuthority.setPublicCapability(target, functionSig, true);
@@ -108,7 +108,7 @@ contract RolesAuthorityTest is DSTestPlus {
         assertFalse(rolesAuthority.isCapabilityPublic(target, functionSig));
     }
 
-    function testCanCallWithAuthorizedRole(
+    function testFuzzCanCallWithAuthorizedRole(
         address user,
         uint8 role,
         address target,
@@ -132,7 +132,7 @@ contract RolesAuthorityTest is DSTestPlus {
         assertFalse(rolesAuthority.canCall(user, target, functionSig));
     }
 
-    function testCanCallPublicCapability(
+    function testFuzzCanCallPublicCapability(
         address user,
         address target,
         bytes4 functionSig

--- a/src/test/SSTORE2.t.sol
+++ b/src/test/SSTORE2.t.sol
@@ -60,14 +60,14 @@ contract SSTORE2Test is DSTestPlus {
         SSTORE2.read(SSTORE2.write(hex"11223344"), 41000, 42000);
     }
 
-    function testWriteRead(bytes calldata testBytes, bytes calldata brutalizeWith)
+    function testFuzzWriteRead(bytes calldata testBytes, bytes calldata brutalizeWith)
         public
         brutalizeMemory(brutalizeWith)
     {
         assertBytesEq(SSTORE2.read(SSTORE2.write(testBytes)), testBytes);
     }
 
-    function testWriteReadCustomStartBound(
+    function testFuzzWriteReadCustomStartBound(
         bytes calldata testBytes,
         uint256 startIndex,
         bytes calldata brutalizeWith
@@ -79,7 +79,7 @@ contract SSTORE2Test is DSTestPlus {
         assertBytesEq(SSTORE2.read(SSTORE2.write(testBytes), startIndex), bytes(testBytes[startIndex:]));
     }
 
-    function testWriteReadCustomBounds(
+    function testFuzzWriteReadCustomBounds(
         bytes calldata testBytes,
         uint256 startIndex,
         uint256 endIndex,
@@ -98,7 +98,7 @@ contract SSTORE2Test is DSTestPlus {
         );
     }
 
-    function testFailReadInvalidPointer(address pointer, bytes calldata brutalizeWith)
+    function testFailFuzzReadInvalidPointer(address pointer, bytes calldata brutalizeWith)
         public
         view
         brutalizeMemory(brutalizeWith)
@@ -108,7 +108,7 @@ contract SSTORE2Test is DSTestPlus {
         SSTORE2.read(pointer);
     }
 
-    function testFailReadInvalidPointerCustomStartBound(
+    function testFailFuzzReadInvalidPointerCustomStartBound(
         address pointer,
         uint256 startIndex,
         bytes calldata brutalizeWith
@@ -118,7 +118,7 @@ contract SSTORE2Test is DSTestPlus {
         SSTORE2.read(pointer, startIndex);
     }
 
-    function testFailReadInvalidPointerCustomBounds(
+    function testFailFuzzReadInvalidPointerCustomBounds(
         address pointer,
         uint256 startIndex,
         uint256 endIndex,
@@ -129,7 +129,7 @@ contract SSTORE2Test is DSTestPlus {
         SSTORE2.read(pointer, startIndex, endIndex);
     }
 
-    function testFailWriteReadCustomStartBoundOutOfRange(
+    function testFailFuzzWriteReadCustomStartBoundOutOfRange(
         bytes calldata testBytes,
         uint256 startIndex,
         bytes calldata brutalizeWith
@@ -139,7 +139,7 @@ contract SSTORE2Test is DSTestPlus {
         SSTORE2.read(SSTORE2.write(testBytes), startIndex);
     }
 
-    function testFailWriteReadCustomBoundsOutOfRange(
+    function testFailFuzzWriteReadCustomBoundsOutOfRange(
         bytes calldata testBytes,
         uint256 startIndex,
         uint256 endIndex,

--- a/src/test/SafeCastLib.t.sol
+++ b/src/test/SafeCastLib.t.sol
@@ -87,109 +87,109 @@ contract SafeCastLibTest is DSTestPlus {
         SafeCastLib.safeCastTo8(type(uint8).max + 1);
     }
 
-    function testSafeCastTo248(uint256 x) public {
+    function testFuzzSafeCastTo248(uint256 x) public {
         x = bound(x, 0, type(uint248).max);
 
         assertEq(SafeCastLib.safeCastTo248(x), x);
     }
 
-    function testSafeCastTo224(uint256 x) public {
+    function testFuzzSafeCastTo224(uint256 x) public {
         x = bound(x, 0, type(uint224).max);
 
         assertEq(SafeCastLib.safeCastTo224(x), x);
     }
 
-    function testSafeCastTo192(uint256 x) public {
+    function testFuzzSafeCastTo192(uint256 x) public {
         x = bound(x, 0, type(uint192).max);
 
         assertEq(SafeCastLib.safeCastTo192(x), x);
     }
 
-    function testSafeCastTo160(uint256 x) public {
+    function testFuzzSafeCastTo160(uint256 x) public {
         x = bound(x, 0, type(uint160).max);
 
         assertEq(SafeCastLib.safeCastTo160(x), x);
     }
 
-    function testSafeCastTo128(uint256 x) public {
+    function testFuzzSafeCastTo128(uint256 x) public {
         x = bound(x, 0, type(uint128).max);
 
         assertEq(SafeCastLib.safeCastTo128(x), x);
     }
 
-    function testSafeCastTo96(uint256 x) public {
+    function testFuzzSafeCastTo96(uint256 x) public {
         x = bound(x, 0, type(uint96).max);
 
         assertEq(SafeCastLib.safeCastTo96(x), x);
     }
 
-    function testSafeCastTo64(uint256 x) public {
+    function testFuzzSafeCastTo64(uint256 x) public {
         x = bound(x, 0, type(uint64).max);
 
         assertEq(SafeCastLib.safeCastTo64(x), x);
     }
 
-    function testSafeCastTo32(uint256 x) public {
+    function testFuzzSafeCastTo32(uint256 x) public {
         x = bound(x, 0, type(uint32).max);
 
         assertEq(SafeCastLib.safeCastTo32(x), x);
     }
 
-    function testSafeCastTo8(uint256 x) public {
+    function testFuzzSafeCastTo8(uint256 x) public {
         x = bound(x, 0, type(uint8).max);
 
         assertEq(SafeCastLib.safeCastTo8(x), x);
     }
 
-    function testFailSafeCastTo248(uint256 x) public {
+    function testFailFuzzSafeCastTo248(uint256 x) public {
         x = bound(x, type(uint248).max + 1, type(uint256).max);
 
         SafeCastLib.safeCastTo248(x);
     }
 
-    function testFailSafeCastTo224(uint256 x) public {
+    function testFailFuzzSafeCastTo224(uint256 x) public {
         x = bound(x, type(uint224).max + 1, type(uint256).max);
 
         SafeCastLib.safeCastTo224(x);
     }
 
-    function testFailSafeCastTo192(uint256 x) public {
+    function testFailFuzzSafeCastTo192(uint256 x) public {
         x = bound(x, type(uint192).max + 1, type(uint256).max);
 
         SafeCastLib.safeCastTo192(x);
     }
 
-    function testFailSafeCastTo160(uint256 x) public {
+    function testFailFuzzSafeCastTo160(uint256 x) public {
         x = bound(x, type(uint160).max + 1, type(uint256).max);
 
         SafeCastLib.safeCastTo160(x);
     }
 
-    function testFailSafeCastTo128(uint256 x) public {
+    function testFailFuzzSafeCastTo128(uint256 x) public {
         x = bound(x, type(uint128).max + 1, type(uint256).max);
 
         SafeCastLib.safeCastTo128(x);
     }
 
-    function testFailSafeCastTo96(uint256 x) public {
+    function testFailFuzzSafeCastTo96(uint256 x) public {
         x = bound(x, type(uint96).max + 1, type(uint256).max);
 
         SafeCastLib.safeCastTo96(x);
     }
 
-    function testFailSafeCastTo64(uint256 x) public {
+    function testFailFuzzSafeCastTo64(uint256 x) public {
         x = bound(x, type(uint64).max + 1, type(uint256).max);
 
         SafeCastLib.safeCastTo64(x);
     }
 
-    function testFailSafeCastTo32(uint256 x) public {
+    function testFailFuzzSafeCastTo32(uint256 x) public {
         x = bound(x, type(uint32).max + 1, type(uint256).max);
 
         SafeCastLib.safeCastTo32(x);
     }
 
-    function testFailSafeCastTo8(uint256 x) public {
+    function testFailFuzzSafeCastTo8(uint256 x) public {
         x = bound(x, type(uint8).max + 1, type(uint256).max);
 
         SafeCastLib.safeCastTo8(x);

--- a/src/test/SafeTransferLib.t.sol
+++ b/src/test/SafeTransferLib.t.sol
@@ -127,7 +127,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeApprove(address(returnsTooLittle), address(0xBEEF), 1e18);
     }
 
-    function testTransferWithMissingReturn(
+    function testFuzzTransferWithMissingReturn(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -135,7 +135,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransfer(address(missingReturn), to, amount);
     }
 
-    function testTransferWithStandardERC20(
+    function testFuzzTransferWithStandardERC20(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -143,7 +143,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransfer(address(erc20), to, amount);
     }
 
-    function testTransferWithReturnsTooMuch(
+    function testFuzzTransferWithReturnsTooMuch(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -151,7 +151,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransfer(address(returnsTooMuch), to, amount);
     }
 
-    function testTransferWithGarbage(
+    function testFuzzTransferWithGarbage(
         address to,
         uint256 amount,
         bytes memory garbage,
@@ -198,7 +198,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransfer(address(returnsGarbage), to, amount);
     }
 
-    function testTransferWithNonContract(
+    function testFuzzTransferWithNonContract(
         address nonContract,
         address to,
         uint256 amount,
@@ -213,7 +213,7 @@ contract SafeTransferLibTest is DSTestPlus {
         SafeTransferLib.safeTransferETH(address(this), 1e18);
     }
 
-    function testTransferFromWithMissingReturn(
+    function testFuzzTransferFromWithMissingReturn(
         address from,
         address to,
         uint256 amount,
@@ -222,7 +222,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransferFrom(address(missingReturn), from, to, amount);
     }
 
-    function testTransferFromWithStandardERC20(
+    function testFuzzTransferFromWithStandardERC20(
         address from,
         address to,
         uint256 amount,
@@ -231,7 +231,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransferFrom(address(erc20), from, to, amount);
     }
 
-    function testTransferFromWithReturnsTooMuch(
+    function testFuzzTransferFromWithReturnsTooMuch(
         address from,
         address to,
         uint256 amount,
@@ -240,7 +240,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransferFrom(address(returnsTooMuch), from, to, amount);
     }
 
-    function testTransferFromWithGarbage(
+    function testFuzzTransferFromWithGarbage(
         address from,
         address to,
         uint256 amount,
@@ -288,7 +288,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransferFrom(address(returnsGarbage), from, to, amount);
     }
 
-    function testTransferFromWithNonContract(
+    function testFuzzTransferFromWithNonContract(
         address nonContract,
         address from,
         address to,
@@ -300,7 +300,7 @@ contract SafeTransferLibTest is DSTestPlus {
         SafeTransferLib.safeTransferFrom(ERC20(nonContract), from, to, amount);
     }
 
-    function testApproveWithMissingReturn(
+    function testFuzzApproveWithMissingReturn(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -308,7 +308,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeApprove(address(missingReturn), to, amount);
     }
 
-    function testApproveWithStandardERC20(
+    function testFuzzApproveWithStandardERC20(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -316,7 +316,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeApprove(address(erc20), to, amount);
     }
 
-    function testApproveWithReturnsTooMuch(
+    function testFuzzApproveWithReturnsTooMuch(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -324,7 +324,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeApprove(address(returnsTooMuch), to, amount);
     }
 
-    function testApproveWithGarbage(
+    function testFuzzApproveWithGarbage(
         address to,
         uint256 amount,
         bytes memory garbage,
@@ -371,7 +371,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeApprove(address(returnsGarbage), to, amount);
     }
 
-    function testApproveWithNonContract(
+    function testFuzzApproveWithNonContract(
         address nonContract,
         address to,
         uint256 amount,
@@ -382,7 +382,7 @@ contract SafeTransferLibTest is DSTestPlus {
         SafeTransferLib.safeApprove(ERC20(nonContract), to, amount);
     }
 
-    function testTransferETH(
+    function testFuzzTransferETH(
         address recipient,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -395,7 +395,7 @@ contract SafeTransferLibTest is DSTestPlus {
         SafeTransferLib.safeTransferETH(recipient, amount);
     }
 
-    function testFailTransferWithReturnsFalse(
+    function testFailFuzzTransferWithReturnsFalse(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -403,7 +403,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransfer(address(returnsFalse), to, amount);
     }
 
-    function testFailTransferWithReverting(
+    function testFailFuzzTransferWithReverting(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -411,7 +411,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransfer(address(reverting), to, amount);
     }
 
-    function testFailTransferWithReturnsTooLittle(
+    function testFailFuzzTransferWithReturnsTooLittle(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -419,7 +419,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransfer(address(returnsTooLittle), to, amount);
     }
 
-    function testFailTransferWithReturnsTwo(
+    function testFailFuzzTransferWithReturnsTwo(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -427,7 +427,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransfer(address(returnsTwo), to, amount);
     }
 
-    function testFailTransferWithGarbage(
+    function testFailFuzzTransferWithGarbage(
         address to,
         uint256 amount,
         bytes memory garbage,
@@ -440,7 +440,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransfer(address(returnsGarbage), to, amount);
     }
 
-    function testFailTransferFromWithReturnsFalse(
+    function testFailFuzzTransferFromWithReturnsFalse(
         address from,
         address to,
         uint256 amount,
@@ -449,7 +449,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransferFrom(address(returnsFalse), from, to, amount);
     }
 
-    function testFailTransferFromWithReverting(
+    function testFailFuzzTransferFromWithReverting(
         address from,
         address to,
         uint256 amount,
@@ -458,7 +458,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransferFrom(address(reverting), from, to, amount);
     }
 
-    function testFailTransferFromWithReturnsTooLittle(
+    function testFailFuzzTransferFromWithReturnsTooLittle(
         address from,
         address to,
         uint256 amount,
@@ -467,7 +467,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransferFrom(address(returnsTooLittle), from, to, amount);
     }
 
-    function testFailTransferFromWithReturnsTwo(
+    function testFailFuzzTransferFromWithReturnsTwo(
         address from,
         address to,
         uint256 amount,
@@ -476,7 +476,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransferFrom(address(returnsTwo), from, to, amount);
     }
 
-    function testFailTransferFromWithGarbage(
+    function testFailFuzzTransferFromWithGarbage(
         address from,
         address to,
         uint256 amount,
@@ -490,7 +490,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeTransferFrom(address(returnsGarbage), from, to, amount);
     }
 
-    function testFailApproveWithReturnsFalse(
+    function testFailFuzzApproveWithReturnsFalse(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -498,7 +498,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeApprove(address(returnsFalse), to, amount);
     }
 
-    function testFailApproveWithReverting(
+    function testFailFuzzApproveWithReverting(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -506,7 +506,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeApprove(address(reverting), to, amount);
     }
 
-    function testFailApproveWithReturnsTooLittle(
+    function testFailFuzzApproveWithReturnsTooLittle(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -514,7 +514,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeApprove(address(returnsTooLittle), to, amount);
     }
 
-    function testFailApproveWithReturnsTwo(
+    function testFailFuzzApproveWithReturnsTwo(
         address to,
         uint256 amount,
         bytes calldata brutalizeWith
@@ -522,7 +522,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeApprove(address(returnsTwo), to, amount);
     }
 
-    function testFailApproveWithGarbage(
+    function testFailFuzzApproveWithGarbage(
         address to,
         uint256 amount,
         bytes memory garbage,
@@ -535,7 +535,7 @@ contract SafeTransferLibTest is DSTestPlus {
         verifySafeApprove(address(returnsGarbage), to, amount);
     }
 
-    function testFailTransferETHToContractWithoutFallback(uint256 amount, bytes calldata brutalizeWith)
+    function testFailFuzzTransferETHToContractWithoutFallback(uint256 amount, bytes calldata brutalizeWith)
         public
         brutalizeMemory(brutalizeWith)
     {

--- a/src/test/WETH.t.sol
+++ b/src/test/WETH.t.sol
@@ -63,7 +63,7 @@ contract WETHTest is DSTestPlus {
         assertEq(weth.totalSupply(), 0.5 ether);
     }
 
-    function testDeposit(uint256 amount) public {
+    function testFuzzDeposit(uint256 amount) public {
         amount = bound(amount, 0, address(this).balance);
 
         assertEq(weth.balanceOf(address(this)), 0);
@@ -75,7 +75,7 @@ contract WETHTest is DSTestPlus {
         assertEq(weth.totalSupply(), amount);
     }
 
-    function testFallbackDeposit(uint256 amount) public {
+    function testFuzzFallbackDeposit(uint256 amount) public {
         amount = bound(amount, 0, address(this).balance);
 
         assertEq(weth.balanceOf(address(this)), 0);
@@ -87,7 +87,7 @@ contract WETHTest is DSTestPlus {
         assertEq(weth.totalSupply(), amount);
     }
 
-    function testWithdraw(uint256 depositAmount, uint256 withdrawAmount) public {
+    function testFuzzWithdraw(uint256 depositAmount, uint256 withdrawAmount) public {
         depositAmount = bound(depositAmount, 0, address(this).balance);
         withdrawAmount = bound(withdrawAmount, 0, depositAmount);
 


### PR DESCRIPTION
## Description
Replaces #181

Change naming convention of tests to testFuzz...(..) and testFailFuzz..(...). This allows for easier filtering and visual inspection. i.e. to run all non-fuzz tests you do forge test --no-match-test "testFuzz|testFailFuzz"

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge snapshot`?
- [x] Ran `npm run lint`?
- [x] Ran `forge test`?

Verified all tests updated correctly visually as well as `forge test --no-match-test "testFuzz|testFailFuzz" | grep runs` and `forge test --match-test "testFuzz|testFailFuzz" | grep gas` not having output (basically the above filters out all fuzz or normal tests, and if there were output it means a test's name didnt change to the new convention). Unfortunately some of the benefit of this renaming is reduced because of testFailFuzz requirement.

Additionally this has the benefit of allowing you to use forge snapshot --no-match-test "testFuzz|testFailFuzz" which strips fuzz tests from being included in snapshot output
