### PR TITLE
Enable bi-directional conversion between bytes32 and address

### DIFF
--- a/src/test/Bytes32AddressLib.t.sol
+++ b/src/test/Bytes32AddressLib.t.sol
@@ -19,4 +19,13 @@ contract Bytes32AddressLibTest is DSTestPlus {
             0xCAfeBeefFeedfAceCAFeBEEffEEDfaCecafEBeeF
         );
     }
+
+    function testFromFirst20Bytes() public {
+        assertEq(
+            Bytes32AddressLib.fromFirst20Bytes(
+                Bytes32AddressLib.fillLast12Bytes(0xfEEDFaCEcaFeBEEFfEEDFACecaFEBeeFfeEdfAce)
+            ),
+            0xfEEDFaCEcaFeBEEFfEEDFACecaFEBeeFfeEdfAce
+        );
+    }
 }

--- a/src/utils/Bytes32AddressLib.sol
+++ b/src/utils/Bytes32AddressLib.sol
@@ -8,6 +8,10 @@ library Bytes32AddressLib {
         return address(uint160(uint256(bytesValue)));
     }
 
+    function fromFirst20Bytes(bytes32 bytesValue) internal pure returns (address) {
+        return address(uint160(bytes20(bytesValue)));
+    }
+
     function fillLast12Bytes(address addressValue) internal pure returns (bytes32) {
         return bytes32(bytes20(addressValue));
     }


### PR DESCRIPTION
## Description

Add a method for converting a right-padded bytes32 address (e.g. return value of `fillLast12Bytes`) back into the original 20-byte address.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge snapshot`?
- [x] Ran `npm run lint`?
- [x] Ran `forge test`?
