### PR TITLE
♻️ Add missing pure modifiers to math functions

### DIFF
--- a/src/utils/BitwiseLib.sol
+++ b/src/utils/BitwiseLib.sol
@@ -9,7 +9,7 @@ library BitwiseLib {
     // @returns floor(log2(x)) if x is nonzero, otherwise 0.
     //          This is the same as the location of the highest set bit.
     // Consumes 232 gas. This could have been an 3 gas EVM opcode though.
-    function ilog2(uint256 x) internal returns (uint256 r) {
+    function ilog2(uint256 x) internal pure returns (uint256 r) {
         assembly {
             r := shl(7, lt(0xffffffffffffffffffffffffffffffff, x))
             r := or(r, shl(6, lt(0xffffffffffffffff, shr(r, x))))

--- a/src/utils/FixedPointMathLib.sol
+++ b/src/utils/FixedPointMathLib.sol
@@ -97,7 +97,7 @@ library FixedPointMathLib {
     //   reverts with `LnNegativeUndefined()` if x is negative, and with
     //   `Overflow()` if x is zero.
     // Consumes about 670 gas.
-    function lnWad(int256 x) internal returns (int256 r) {
+    function lnWad(int256 x) internal pure returns (int256 r) {
         unchecked {
             if (x < 1) {
                 if (x < 0) revert LnNegativeUndefined();


### PR DESCRIPTION
## Description

Added the "pure" modifiers to 2 functions: `ilog2` in `BitwiseLib.sol` & `lnWad` in `FixedPointMathLib.sol`.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge snapshot`?
- [x] Ran `npm run lint`?
- [x] Ran `forge test`?

