### PR TITLE
[WETH test] Add Reentrancy test

### DIFF
--- a/src/test/WETH.t.sol
+++ b/src/test/WETH.t.sol
@@ -7,6 +7,7 @@ import {DSInvariantTest} from "./utils/DSInvariantTest.sol";
 import {SafeTransferLib} from "../utils/SafeTransferLib.sol";
 
 import {WETH} from "../tokens/WETH.sol";
+import "./utils/mocks/MockReentrancyHack.sol";
 
 contract WETHTest is DSTestPlus {
     WETH weth;
@@ -102,6 +103,17 @@ contract WETHTest is DSTestPlus {
         assertEq(balanceAfterWithdraw, balanceBeforeWithdraw + withdrawAmount);
         assertEq(weth.balanceOf(address(this)), depositAmount - withdrawAmount);
         assertEq(weth.totalSupply(), depositAmount - withdrawAmount);
+    }
+
+    function testReentrancy() public {
+        SafeTransferLib.safeTransferETH(address(weth), 1 ether);
+
+        assertEq(address(weth).balance, 1 ether);
+
+        MockReentrancyHack hacker = new MockReentrancyHack(address(weth));
+
+        hevm.expectRevert("ETH_TRANSFER_FAILED");
+        hacker.attack{value: 1 ether}();
     }
 
     receive() external payable {}

--- a/src/test/utils/MockReentrancyHack.sol
+++ b/src/test/utils/MockReentrancyHack.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+interface IWETH {
+    function deposit() external payable;
+
+    function withdraw(uint256) external;
+}
+
+contract MockReentrancyHack {
+    IWETH weth;
+
+    constructor(address _addr) {
+        weth = IWETH(_addr);
+    }
+
+    function attack() external payable {
+        require(address(this).balance == 1 ether);
+        weth.deposit{value: 1 ether}();
+        weth.withdraw(1 ether);
+    }
+
+    receive() external payable {
+        if (address(weth).balance >= 1 ether) {
+            weth.withdraw(1 ether);
+        }
+    }
+}


### PR DESCRIPTION
Possible attack vector:
_burn is called after eth transfer in WETH withdraw().
In Erc20 _burn(), if the code "balance[from] -=amount"
is unchecked or older solidity compiler version (0.6 or lesser) is used
which does not check for arithmetic underflow.

Signed-off-by: Jagadish Krishnamoorthy <jagdish.krishna@gmail.com>

## Description

Describe the changes made in your pull request here.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Ran `forge snapshot`?
- [ ] Ran `npm run lint`?
- [ ] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._
