### PR TITLE
Delete approved if have

### DIFF
--- a/src/tokens/ERC721.sol
+++ b/src/tokens/ERC721.sol
@@ -103,7 +103,9 @@ abstract contract ERC721 {
 
         _ownerOf[id] = to;
 
-        delete getApproved[id];
+        if (getApproved[id] != address(0)) {
+            delete getApproved[id];
+        }
 
         emit Transfer(from, to, id);
     }


### PR DESCRIPTION
## Description

Clear `getApproved` only if have an approved address

Statistically, this would save gas, the sum of an `owner` transfer and `isApprovedForAll` transfer is greater than an `approved` transfer

Save 80 gas if the `getApproved` haven't a approved
Spend 150 gas if the `getApproved` have a approved
_(In each `transferFrom`, according to my tests)_

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [X] Ran `forge snapshot`?
- [X] Ran `npm run lint`?
- [X] Ran `forge test`?