### PR TITLE
⚔️ functions clashing with forge-std/Test.sol

### DIFF
--- a/src/test/utils/DSTestPlus.sol
+++ b/src/test/utils/DSTestPlus.sol
@@ -63,12 +63,7 @@ contract DSTestPlus is DSTest {
         emit log_named_uint(string(abi.encodePacked(checkpointLabel, " Gas")), gasDelta);
     }
 
-    function fail(string memory err) internal virtual {
-        emit log_named_string("Error", err);
-        fail();
-    }
-
-    function assertFalse(bool data) internal virtual {
+    function _assertFalse(bool data) private {
         assertTrue(!data);
     }
 
@@ -89,7 +84,7 @@ contract DSTestPlus is DSTest {
     }
 
     function assertBoolEq(bool a, bool b) internal virtual {
-        b ? assertTrue(a) : assertFalse(a);
+        b ? assertTrue(a) : _assertFalse(a);
     }
 
     function assertApproxEq(
@@ -143,26 +138,6 @@ contract DSTestPlus is DSTest {
         for (uint256 i = 0; i < a.length; i++) {
             assertEq(a[i], b[i]);
         }
-    }
-
-    function bound(
-        uint256 x,
-        uint256 min,
-        uint256 max
-    ) internal returns (uint256 result) {
-        require(max >= min, "MAX_LESS_THAN_MIN");
-
-        uint256 size = max - min;
-
-        if (size == 0) result = min;
-        else if (size == type(uint256).max) result = x;
-        else {
-            ++size; // Make max inclusive.
-            uint256 mod = x % size;
-            result = min + mod;
-        }
-
-        emit log_named_uint("Bound Result", result);
     }
 
     function min3(


### PR DESCRIPTION
## Description

These functions are now also implemented almost identically in `forge-std/Test.sol` and they make it impossible to inherit both `DSTestPlus` and `Test` , like it is done in the `fuse-flywheel` repo on a few occasions:
https://github.com/fei-protocol/fuse-flywheel/blob/b1ebb618fe2965727d5a81d74d374a667a1e52b9/src/test/integration/FlywheelDynamicRewardsIntegration.t.sol#L25
https://github.com/fei-protocol/fuse-flywheel/blob/b1ebb618fe2965727d5a81d74d374a667a1e52b9/src/test/integration/pools/FusePool156test.t.sol#L16
https://github.com/fei-protocol/fuse-flywheel/blob/b1ebb618fe2965727d5a81d74d374a667a1e52b9/src/test/integration/pools/FusePool190test.t.sol#L15

*This is a draft PR just to gather opinions and the checklist below has not been done*

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [ ] Ran `forge snapshot`?
- [ ] Ran `npm run lint`?
- [ ] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._
