### PR TITLE
Custom errors

### DIFF
--- a/src/auth/Auth.sol
+++ b/src/auth/Auth.sol
@@ -13,6 +13,8 @@ abstract contract Auth {
 
     Authority public authority;
 
+    error UNAUTHORIZED();
+
     constructor(address _owner, Authority _authority) {
         owner = _owner;
         authority = _authority;
@@ -22,8 +24,9 @@ abstract contract Auth {
     }
 
     modifier requiresAuth() virtual {
-        require(isAuthorized(msg.sender, msg.sig), "UNAUTHORIZED");
-
+        if (msg.sender != owner) {
+            revert UNAUTHORIZED();
+        }
         _;
     }
 

--- a/src/auth/Auth.sol
+++ b/src/auth/Auth.sol
@@ -24,7 +24,7 @@ abstract contract Auth {
     }
 
     modifier requiresAuth() virtual {
-        if (msg.sender != owner) {
+        if (!isAuthorized(msg.sender, msg.sig)) {
             revert UNAUTHORIZED();
         }
         _;

--- a/src/auth/Owned.sol
+++ b/src/auth/Owned.sol
@@ -16,9 +16,16 @@ abstract contract Owned {
 
     address public owner;
 
-    modifier onlyOwner() virtual {
-        require(msg.sender == owner, "UNAUTHORIZED");
+    /*//////////////////////////////////////////////////////////////
+                            CUSTOM ERRORS
+    //////////////////////////////////////////////////////////////*/
 
+    error UNAUTHORIZED();
+
+    modifier onlyOwner() virtual {
+        if (msg.sender != owner) {
+            revert UNAUTHORIZED();
+        }
         _;
     }
 

--- a/src/test/ERC721.t.sol
+++ b/src/test/ERC721.t.sol
@@ -78,7 +78,7 @@ contract ERC721Test is DSTestPlus {
 
         assertEq(token.balanceOf(address(0xBEEF)), 0);
 
-        hevm.expectRevert("NOT_MINTED");
+        hevm.expectRevert(abi.encodeWithSignature("NOT_MINTED()"));
         token.ownerOf(1337);
     }
 
@@ -100,7 +100,7 @@ contract ERC721Test is DSTestPlus {
         assertEq(token.balanceOf(address(this)), 0);
         assertEq(token.getApproved(1337), address(0));
 
-        hevm.expectRevert("NOT_MINTED");
+        hevm.expectRevert(abi.encodeWithSignature("NOT_MINTED()"));
         token.ownerOf(1337);
     }
 
@@ -392,7 +392,7 @@ contract ERC721Test is DSTestPlus {
 
         assertEq(token.balanceOf(to), 0);
 
-        hevm.expectRevert("NOT_MINTED");
+        hevm.expectRevert(abi.encodeWithSignature("NOT_MINTED()"));
         token.ownerOf(id);
     }
 
@@ -416,7 +416,7 @@ contract ERC721Test is DSTestPlus {
         assertEq(token.balanceOf(address(this)), 0);
         assertEq(token.getApproved(id), address(0));
 
-        hevm.expectRevert("NOT_MINTED");
+        hevm.expectRevert(abi.encodeWithSignature("NOT_MINTED()"));
         token.ownerOf(id);
     }
 

--- a/src/test/Owned.t.sol
+++ b/src/test/Owned.t.sol
@@ -34,7 +34,7 @@ contract OwnedTest is DSTestPlus {
 
         mockOwned.setOwner(owner);
 
-        hevm.expectRevert("UNAUTHORIZED");
+        hevm.expectRevert(abi.encodeWithSignature("UNAUTHORIZED()"));
         mockOwned.updateFlag();
     }
 }

--- a/src/tokens/ERC1155.sol
+++ b/src/tokens/ERC1155.sol
@@ -69,7 +69,7 @@ abstract contract ERC1155 {
         uint256 amount,
         bytes calldata data
     ) public virtual {
-        if (msg.sender != from || !isApprovedForAll[from][msg.sender]) {
+        if (msg.sender != from && !isApprovedForAll[from][msg.sender]) {
             revert NOT_AUTHORIZED();
         }
 
@@ -78,11 +78,12 @@ abstract contract ERC1155 {
 
         emit TransferSingle(msg.sender, from, to, id, amount);
 
-        if (to.code.length != 0
+        if ((to.code.length == 0 
                 ? to != address(0)
-                : ERC1155TokenReceiver(to).onERC1155Received(msg.sender, from, id, amount, data) !=
-                    ERC1155TokenReceiver.onERC1155Received.selector) {
-            revert UNSAFE_RECIPIENT();
+                : ERC1155TokenReceiver(to).onERC1155Received(msg.sender, from, id, amount, data) == 
+                ERC1155TokenReceiver.onERC1155Received.selector)
+                == false) {
+                    revert UNSAFE_RECIPIENT();
         }
     }
 
@@ -92,12 +93,12 @@ abstract contract ERC1155 {
         uint256[] calldata ids,
         uint256[] calldata amounts,
         bytes calldata data
-    ) public virtual {
+    ) public virtual {     
         if (ids.length != amounts.length) {
             revert LENGTH_MISMATCH();
         }
 
-        if (msg.sender != from || !isApprovedForAll[from][msg.sender]) {
+        if (msg.sender != from && !isApprovedForAll[from][msg.sender]) {
             revert NOT_AUTHORIZED();
         }
 
@@ -122,11 +123,12 @@ abstract contract ERC1155 {
         emit TransferBatch(msg.sender, from, to, ids, amounts);
 
 
-        if (to.code.length != 0
+        if ((to.code.length == 0 
                 ? to != address(0)
-                : ERC1155TokenReceiver(to).onERC1155BatchReceived(msg.sender, from, ids, amounts, data) !=
-                    ERC1155TokenReceiver.onERC1155BatchReceived.selector) {
-            revert UNSAFE_RECIPIENT();
+                : ERC1155TokenReceiver(to).onERC1155BatchReceived(msg.sender, from, ids, amounts, data) == 
+                ERC1155TokenReceiver.onERC1155BatchReceived.selector)
+                == false) {
+                    revert UNSAFE_RECIPIENT();
         }
     }
 
@@ -136,10 +138,10 @@ abstract contract ERC1155 {
         virtual
         returns (uint256[] memory balances)
     {
-        if (owners.length != ids.length) {
+        if ((owners.length == ids.length) == false) {
             revert LENGTH_MISMATCH();
         }
-
+        
         balances = new uint256[](owners.length);
 
         // Unchecked because the only math done is incrementing
@@ -176,11 +178,12 @@ abstract contract ERC1155 {
 
         emit TransferSingle(msg.sender, address(0), to, id, amount);
 
-        if (to.code.length != 0
+        if ((to.code.length == 0 
                 ? to != address(0)
-                : ERC1155TokenReceiver(to).onERC1155Received(msg.sender, address(0), id, amount, data) !=
-                    ERC1155TokenReceiver.onERC1155Received.selector) {
-            revert UNSAFE_RECIPIENT();
+                : ERC1155TokenReceiver(to).onERC1155Received(msg.sender, address(0), id, amount, data) == 
+                ERC1155TokenReceiver.onERC1155Received.selector)
+                == false) {
+                    revert UNSAFE_RECIPIENT();
         }
     }
 
@@ -208,11 +211,12 @@ abstract contract ERC1155 {
 
         emit TransferBatch(msg.sender, address(0), to, ids, amounts);
 
-        if (to.code.length != 0
+        if ((to.code.length == 0 
                 ? to != address(0)
-                : ERC1155TokenReceiver(to).onERC1155BatchReceived(msg.sender, address(0), ids, amounts, data) !=
-                    ERC1155TokenReceiver.onERC1155BatchReceived.selector) {
-            revert UNSAFE_RECIPIENT();
+                : ERC1155TokenReceiver(to).onERC1155BatchReceived(msg.sender, address(0), ids, amounts, data) == 
+                ERC1155TokenReceiver.onERC1155BatchReceived.selector)
+                == false) {
+                    revert UNSAFE_RECIPIENT();
         }
     }
 

--- a/src/tokens/ERC20.sol
+++ b/src/tokens/ERC20.sol
@@ -48,9 +48,9 @@ abstract contract ERC20 {
                             CUSTOM ERRORS
     //////////////////////////////////////////////////////////////*/
 
-    error Invalid(address signer, address owner);
+    error INVALID_SIGNATURE();
 
-    error Deadline(uint256 deadline, uint256 timestamp);
+    error DEADLINE();
 
     /*//////////////////////////////////////////////////////////////
                                CONSTRUCTOR
@@ -131,7 +131,7 @@ abstract contract ERC20 {
         bytes32 s
     ) public virtual {
         if (deadline < block.timestamp) {
-            revert Deadline(deadline, block.timestamp);
+            revert DEADLINE();
         }
         // Unchecked because the only math done is incrementing
         // the owner's nonce which cannot realistically overflow.
@@ -161,7 +161,7 @@ abstract contract ERC20 {
             );
 
             if (recoveredAddress != address(0) && recoveredAddress != owner) {
-                revert Invalid(msg.sender, owner);
+                revert INVALID();
             }
 
             allowance[recoveredAddress][spender] = value;

--- a/src/tokens/ERC20.sol
+++ b/src/tokens/ERC20.sol
@@ -161,7 +161,7 @@ abstract contract ERC20 {
             );
 
             if (recoveredAddress != address(0) && recoveredAddress != owner) {
-                revert INVALID();
+                revert INVALID_SIGNATURE();
             }
 
             allowance[recoveredAddress][spender] = value;

--- a/src/tokens/ERC20.sol
+++ b/src/tokens/ERC20.sol
@@ -45,6 +45,14 @@ abstract contract ERC20 {
     mapping(address => uint256) public nonces;
 
     /*//////////////////////////////////////////////////////////////
+                            CUSTOM ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    error Invalid(address signer, address owner);
+
+    error Deadline(uint256 deadline, uint256 timestamp);
+
+    /*//////////////////////////////////////////////////////////////
                                CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
@@ -122,8 +130,9 @@ abstract contract ERC20 {
         bytes32 r,
         bytes32 s
     ) public virtual {
-        require(deadline >= block.timestamp, "PERMIT_DEADLINE_EXPIRED");
-
+        if (deadline < block.timestamp) {
+            revert Deadline(deadline, block.timestamp);
+        }
         // Unchecked because the only math done is incrementing
         // the owner's nonce which cannot realistically overflow.
         unchecked {
@@ -151,7 +160,9 @@ abstract contract ERC20 {
                 s
             );
 
-            require(recoveredAddress != address(0) && recoveredAddress == owner, "INVALID_SIGNER");
+            if (recoveredAddress != address(0) && recoveredAddress != owner) {
+                revert Invalid(msg.sender, owner);
+            }
 
             allowance[recoveredAddress][spender] = value;
         }

--- a/src/tokens/ERC721.sol
+++ b/src/tokens/ERC721.sol
@@ -86,7 +86,7 @@ abstract contract ERC721 {
     function approve(address spender, uint256 id) public virtual {
         address owner = _ownerOf[id];
 
-        if (msg.sender != owner || !isApprovedForAll[owner][msg.sender]) {
+        if (msg.sender != owner && !isApprovedForAll[owner][msg.sender]) {
             revert NOT_AUTHORIZED();
         }
 
@@ -114,7 +114,7 @@ abstract contract ERC721 {
             revert INVALID_RECIPIENT();
         }
 
-        if (msg.sender != from || !isApprovedForAll[from][msg.sender] || msg.sender != getApproved[id]) {
+        if (msg.sender != from && !isApprovedForAll[from][msg.sender] && msg.sender != getApproved[id]) {
             revert NOT_AUTHORIZED();
         }
 
@@ -140,7 +140,7 @@ abstract contract ERC721 {
     ) public virtual {
         transferFrom(from, to, id);
 
-        if(to.code.length != 0 ||
+        if(to.code.length != 0 &&
                 ERC721TokenReceiver(to).onERC721Received(msg.sender, from, id, "") !=
                 ERC721TokenReceiver.onERC721Received.selector) {       
             revert UNSAFE_RECIPIENT();
@@ -155,7 +155,7 @@ abstract contract ERC721 {
     ) public virtual {
         transferFrom(from, to, id);
 
-        if(to.code.length != 0 ||
+        if(to.code.length != 0 &&
                 ERC721TokenReceiver(to).onERC721Received(msg.sender, from, id, data) !=
                 ERC721TokenReceiver.onERC721Received.selector) {
             revert UNSAFE_RECIPIENT();
@@ -222,7 +222,7 @@ abstract contract ERC721 {
     function _safeMint(address to, uint256 id) internal virtual {
         _mint(to, id);
 
-        if(to.code.length != 0 ||
+        if(to.code.length != 0 &&
                 ERC721TokenReceiver(to).onERC721Received(msg.sender, address(0), id, "") !=
                 ERC721TokenReceiver.onERC721Received.selector) {
             revert UNSAFE_RECIPIENT();
@@ -236,7 +236,7 @@ abstract contract ERC721 {
     ) internal virtual {
         _mint(to, id);
 
-        if(to.code.length != 0 ||
+        if(to.code.length != 0 &&
                 ERC721TokenReceiver(to).onERC721Received(msg.sender, address(0), id, data) !=
                 ERC721TokenReceiver.onERC721Received.selector) {
             revert UNSAFE_RECIPIENT();

--- a/src/utils/ReentrancyGuard.sol
+++ b/src/utils/ReentrancyGuard.sol
@@ -7,8 +7,12 @@ pragma solidity >=0.8.0;
 abstract contract ReentrancyGuard {
     uint256 private locked = 1;
 
+    error REENTRANCY();
+
     modifier nonReentrant() virtual {
-        require(locked == 1, "REENTRANCY");
+        if (locked != 1) {
+            revert REENTRANCY();
+        }
 
         locked = 2;
 

--- a/src/utils/SafeCastLib.sol
+++ b/src/utils/SafeCastLib.sol
@@ -5,56 +5,76 @@ pragma solidity >=0.8.0;
 /// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/utils/SafeCastLib.sol)
 /// @author Modified from OpenZeppelin (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/math/SafeCast.sol)
 library SafeCastLib {
+
+    error CAST();
     function safeCastTo248(uint256 x) internal pure returns (uint248 y) {
-        require(x < 1 << 248);
+        if (!(x < 1 << 248)){
+            revert CAST();
+        }
 
         y = uint248(x);
     }
 
     function safeCastTo224(uint256 x) internal pure returns (uint224 y) {
-        require(x < 1 << 224);
+        if (!(x < 1 << 224)){
+            revert CAST();
+        }
 
         y = uint224(x);
     }
 
     function safeCastTo192(uint256 x) internal pure returns (uint192 y) {
-        require(x < 1 << 192);
+        if (!(x < 1 << 192)){
+            revert CAST();
+        }
 
         y = uint192(x);
     }
 
     function safeCastTo160(uint256 x) internal pure returns (uint160 y) {
-        require(x < 1 << 160);
+        if (!(x < 1 << 160)){
+            revert CAST();
+        }
 
         y = uint160(x);
     }
 
     function safeCastTo128(uint256 x) internal pure returns (uint128 y) {
-        require(x < 1 << 128);
+        if (!(x < 1 << 128)){
+            revert CAST();
+        }
 
         y = uint128(x);
     }
 
     function safeCastTo96(uint256 x) internal pure returns (uint96 y) {
-        require(x < 1 << 96);
+        if (!(x < 1 << 96)){
+            revert CAST();
+        }
 
         y = uint96(x);
     }
 
     function safeCastTo64(uint256 x) internal pure returns (uint64 y) {
-        require(x < 1 << 64);
+        if (!(x < 1 << 64)){
+            revert CAST();
+        }
 
         y = uint64(x);
     }
 
     function safeCastTo32(uint256 x) internal pure returns (uint32 y) {
-        require(x < 1 << 32);
+        if (!(x < 1 << 32)){
+            revert CAST();
+        }
 
         y = uint32(x);
     }
 
     function safeCastTo8(uint256 x) internal pure returns (uint8 y) {
-        require(x < 1 << 8);
+        if (!(x < 1 << 8)){
+            revert CAST();
+        }
 
         y = uint8(x);
     }

--- a/src/utils/SafeTransferLib.sol
+++ b/src/utils/SafeTransferLib.sol
@@ -12,6 +12,11 @@ library SafeTransferLib {
                              ETH OPERATIONS
     //////////////////////////////////////////////////////////////*/
 
+    error ETH();
+    error TRANSFER();
+    error TRANSFER_FROM();
+    error APPROVE();
+
     function safeTransferETH(address to, uint256 amount) internal {
         bool success;
 
@@ -19,8 +24,9 @@ library SafeTransferLib {
             // Transfer the ETH and store if it succeeded or not.
             success := call(gas(), to, amount, 0, 0, 0, 0)
         }
-
-        require(success, "ETH_TRANSFER_FAILED");
+        if (!success) {
+            revert ETH();
+        }
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -56,8 +62,9 @@ library SafeTransferLib {
                 call(gas(), token, 0, freeMemoryPointer, 100, 0, 32)
             )
         }
-
-        require(success, "TRANSFER_FROM_FAILED");
+        if (!success) {
+            revert TRANSFER_FROM();
+        }
     }
 
     function safeTransfer(
@@ -87,8 +94,9 @@ library SafeTransferLib {
                 call(gas(), token, 0, freeMemoryPointer, 68, 0, 32)
             )
         }
-
-        require(success, "TRANSFER_FAILED");
+        if (!success) {
+            revert TRANSFER();
+        }
     }
 
     function safeApprove(
@@ -118,7 +126,8 @@ library SafeTransferLib {
                 call(gas(), token, 0, freeMemoryPointer, 68, 0, 32)
             )
         }
-
-        require(success, "APPROVE_FAILED");
+        if (!success) {
+            revert APPROVE();
+        }
     }
 }


### PR DESCRIPTION
## Description

Implemented Custom Errors across all major contracts.

Fixed up tests to accomodate custom errors. 

E.g.
```hevm.expectRevert("NOT_MINTED");``` -> ```hevm.expectRevert(abi.encodeWithSignature("NOT_MINTED()"));```


Gas savings are ubiquitous:
E.g.
```
Revert Strings:
[PASS] testTransfer(address,uint256) (runs: 256, μ: 58776, ~: 60487)
[PASS] testTransferFrom(address,uint256,uint256) (runs: 256, μ: 87191, ~: 92844)
Custom Errors:
[PASS] testTransfer(address,uint256) (runs: 256, μ: 58310, ~: 60487) -- Saves  ~466
[PASS] testTransferFrom(address,uint256,uint256) (runs: 256, μ: 88263, ~: 92844) -- Saves ~1072
```
## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge snapshot`?
- [x] Ran `npm run lint`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._
